### PR TITLE
feat(jsx2mp): omit ts file when copying

### DIFF
--- a/packages/jsx2mp-loader/package.json
+++ b/packages/jsx2mp-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx2mp-loader",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "description": "",
   "files": [
     "src"

--- a/packages/jsx2mp-loader/src/script-loader.js
+++ b/packages/jsx2mp-loader/src/script-loader.js
@@ -14,6 +14,10 @@ const ScriptLoader = __filename;
 
 const MINIAPP_CONFIG_FIELD = 'miniappConfig';
 
+// 1. JSON file will be written later because usingComponents may be modified
+// 2. .d.ts file in rax base components are useless
+const OMIT_FILE_EXTENSION_IN_OUTPUT = ['.json', '.ts'];
+
 module.exports = function scriptLoader(content) {
   const query = parse(this.request);
   if (query.role) {
@@ -92,7 +96,7 @@ module.exports = function scriptLoader(content) {
       mkdirpSync(target);
       copySync(source, target, {
         overwrite: false,
-        filter: filename => !/__(mocks|tests?)__/.test(filename) && extname(filename) !== '.json' // JSON file will be written later because usingComponents may be modified
+        filter: filename => !/__(mocks|tests?)__/.test(filename) && OMIT_FILE_EXTENSION_IN_OUTPUT.indexOf(extname(filename)) === -1
       });
     }
   };


### PR DESCRIPTION
- [x] 拷贝小程序原生代码文件时忽略 ts 文件（Rax 基础组件中存在 .d.ts 文件）