### PR TITLE
fix(miniapp-render): render data computed incorrectly in wechat

### DIFF
--- a/packages/miniapp-render/package.json
+++ b/packages/miniapp-render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miniapp-render",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "DOM simulator for MiniApp",
   "files": [
     "dist"

--- a/packages/miniapp-render/src/utils/getProperty.js
+++ b/packages/miniapp-render/src/utils/getProperty.js
@@ -19,7 +19,7 @@ export default function(obj, path, cache) {
   let value = obj;
   let parentRendered = true;
 
-  if (Object.prototype.toString.call(value) !== '[object Object]') {
+  if (Object.prototype.toString.call(value) !== '[object Object]' && !Array.isArray(value)) {
     return {
       parentRendered,
       value,


### PR DESCRIPTION
- [x] 修复微信小程序中带兄弟元素子节点从 comment 转换为实际元素时处理渲染数据的 bug 