### PR TITLE
Release/miniapp 1.2.6

### DIFF
--- a/packages/miniapp-render/package.json
+++ b/packages/miniapp-render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miniapp-render",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "DOM simulator for MiniApp",
   "files": [
     "dist"

--- a/packages/miniapp-render/src/node/element.js
+++ b/packages/miniapp-render/src/node/element.js
@@ -28,7 +28,6 @@ class Element extends Node {
     if (this.id) {
       this.ownerDocument.__idMap.set(this.id, this);
     }
-
   }
 
   // Override the $$destroy method of the parent class

--- a/packages/miniapp-render/src/node/element.js
+++ b/packages/miniapp-render/src/node/element.js
@@ -24,11 +24,11 @@ class Element extends Node {
     cache.setNode(this.__pageId, this.__nodeId, this);
     this.dataset = {};
     this.ownerDocument.__nodeIdMap.set(this.__nodeId, this);
+    this._initAttributes(options.attrs);
     if (this.id) {
       this.ownerDocument.__idMap.set(this.id, this);
     }
 
-    this._initAttributes(options.attrs);
   }
 
   // Override the $$destroy method of the parent class

--- a/packages/miniapp-render/src/utils/getProperty.js
+++ b/packages/miniapp-render/src/utils/getProperty.js
@@ -19,7 +19,7 @@ export default function(obj, path, cache) {
   let value = obj;
   let parentRendered = true;
 
-  if (Object.prototype.toString.call(value) !== '[object Object]') {
+  if (Object.prototype.toString.call(value) !== '[object Object]' && !Array.isArray(value)) {
     return {
       parentRendered,
       value,

--- a/packages/rax-miniapp-babel-plugins/package.json
+++ b/packages/rax-miniapp-babel-plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-miniapp-babel-plugins",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "rax miniapp babel plugins",
   "main": "src/index.js",
   "repository": {

--- a/packages/rax-miniapp-babel-plugins/src/plugins/babel-plugin-handle-native-component.js
+++ b/packages/rax-miniapp-babel-plugins/src/plugins/babel-plugin-handle-native-component.js
@@ -91,6 +91,13 @@ function isInRuntimeDependencies(dependency, runtimeDependencies = []) {
   return false;
 }
 
+function hasDefaultSpecifier(specifiers, t) {
+  for (let specifier of specifiers) {
+    if (t.isImportDefaultSpecifier(specifier)) return true;
+  }
+  return false;
+}
+
 module.exports = function visitor(
   { types: t },
   { usingComponents, target, rootDir, runtimeDependencies }
@@ -112,7 +119,10 @@ module.exports = function visitor(
           if (Array.isArray(specifiers) && t.isStringLiteral(source)) {
             const dirName = dirname(filename);
             const filePath = getTmplPath(source.value, rootDir, dirName, target, runtimeDependencies);
-            if (filePath) {
+
+            // ignore
+            // import { a, b } from 'xxx';
+            if (filePath && hasDefaultSpecifier(specifiers, t)) {
               if (!scanedPageMap[filename]) {
                 scanedPageMap[filename] = true;
                 path.parentPath.traverse({

--- a/packages/rax-miniapp-runtime-webpack-plugin/package.json
+++ b/packages/rax-miniapp-runtime-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-miniapp-runtime-webpack-plugin",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "A webpack plugin for miniapp runtime build",
   "main": "src/index.js",
   "keywords": [

--- a/packages/rax-miniapp-runtime-webpack-plugin/src/generators/app.js
+++ b/packages/rax-miniapp-runtime-webpack-plugin/src/generators/app.js
@@ -42,9 +42,14 @@ function generateAppCSS(compilation, { target, command, rootDir }) {
     resolve(rootDir, 'templates', 'default.css.ejs'),
     'utf-8'
   ));
+  // Generate __rax-view and __rax-text style for rax compiled components
+  const raxDefaultCSSTmpl = readFileSync(
+    resolve(rootDir, 'templates', 'rax-default.css.ejs'),
+    'utf-8'
+  );
   addFileToCompilation(compilation, {
     filename: `default.${adapter[target].css}`,
-    content: defaultCSSTmpl,
+    content: defaultCSSTmpl + raxDefaultCSSTmpl,
     target,
     command,
   });

--- a/packages/rax-miniapp-runtime-webpack-plugin/src/templates/rax-default.css.ejs
+++ b/packages/rax-miniapp-runtime-webpack-plugin/src/templates/rax-default.css.ejs
@@ -1,0 +1,14 @@
+.__rax-view {
+  border: 0 solid black;
+  display:flex;
+  flex-direction:column;
+  align-content:flex-start;
+  flex-shrink:0;
+  box-sizing:border-box;
+}
+
+.__rax-text {
+  box-sizing: border-box;
+  display: block;
+  font-size: 32rpx;
+}


### PR DESCRIPTION
- [x] 修复微信小程序中带兄弟元素子节点从 comment 转换为实际元素时处理渲染数据的 bug
- [x] 默认添加 __rax-view 及 __rax-text，防止运行时方案中使用编译时组件样式存在问题
- [x] 修复使用编译时组件时无法处理 import A, {a, b} from 'component' 的 bug
- [x] 修复创建 element 时初始化 attribute 时机错误导致 id 无法获取的问题