### PR TITLE
fix(miniapp): scroll-into-view doesn't work in wechat and map onRegionChange error in ali miniapp

### DIFF
--- a/packages/miniapp-render/package.json
+++ b/packages/miniapp-render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miniapp-render",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "DOM simulator for MiniApp",
   "files": [
     "dist"

--- a/packages/miniapp-render/src/builtInComponents/map.js
+++ b/packages/miniapp-render/src/builtInComponents/map.js
@@ -1,3 +1,6 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { isMiniApp, isWeChatMiniProgram } from 'universal-env';
+
 export default {
   name: 'map',
   singleEvents: [{
@@ -29,7 +32,19 @@ export default {
       name: 'onMapRegionChange',
       eventName: 'regionchange',
       middleware(evt, domNode) {
-        if (!evt.detail.causedBy) evt.detail.causedBy = evt.causedBy;
+        if (isMiniApp) {
+          evt.detail = {
+            type: evt.detail,
+            latitude: evt.latitude,
+            longitude: evt.longitude,
+            scale: evt.scale,
+            skew: evt.skew,
+            rotate: evt.rotate,
+            causedBy: evt.causedBy
+          };
+        } else {
+          if (!evt.detail.causedBy) evt.detail.causedBy = evt.causedBy;
+        }
       }
     }
   ]

--- a/packages/miniapp-render/src/builtInComponents/map.js
+++ b/packages/miniapp-render/src/builtInComponents/map.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { isMiniApp, isWeChatMiniProgram } from 'universal-env';
+import { isMiniApp } from 'universal-env';
 
 export default {
   name: 'map',

--- a/packages/rax-miniapp-runtime-webpack-plugin/package.json
+++ b/packages/rax-miniapp-runtime-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-miniapp-runtime-webpack-plugin",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "A webpack plugin for miniapp runtime build",
   "main": "src/index.js",
   "keywords": [

--- a/packages/rax-miniapp-runtime-webpack-plugin/src/templates/wechat-miniprogram/root.xml.ejs
+++ b/packages/rax-miniapp-runtime-webpack-plugin/src/templates/wechat-miniprogram/root.xml.ejs
@@ -125,7 +125,14 @@
     refresher-background="{{r['refresher-background']}}"
     refresher-triggered="{{r['refresher-triggered']}}"
   >
-    <template is="children" data="{{r: r.children}}" />
+    <block wx:for="{{r.children}}" wx:key="nodeId">
+      <block wx:if="{{item.nodeId}}">
+        <template is="{{item.nodeType || 'h-element'}}" data="{{r: item}}" />
+      </block>
+      <block wx:else>
+        <block>{{item.content}}</block>
+      </block>
+    </block>
   </scroll-view>
 </template>
 


### PR DESCRIPTION
- [x] 修复微信端 scroll-view 子节点通过自定义组件渲染时机滞后，导致 scroll-into-view 无法准确计算位置从而失效的问题
- [x] 修复支付宝小程序端 onRegionChange 事件不存在 evt.detail 变量导致的 bug