### PR TITLE
fix: runtime mode multi native component render error

### DIFF
--- a/packages/rax-miniapp-babel-plugins/src/utils/handleComponentAST.js
+++ b/packages/rax-miniapp-babel-plugins/src/utils/handleComponentAST.js
@@ -9,9 +9,10 @@ function collectComponentAttr(components, t) {
         components[tagName] = {
           props: [],
           events: [],
-          node: innerNode,
+          nodes: [],
         };
       }
+      components[tagName].nodes.push(innerNode);
       innerNode.attributes.forEach((attrNode) => {
         if (!t.isJSXIdentifier(attrNode.name)) return;
         const attrName = attrNode.name.name;
@@ -46,12 +47,14 @@ function collectUsings(
     const componentInfo = components[tagName];
     if (componentInfo) {
       // Insert a tag
-      componentInfo.node.attributes.push(
-        t.jsxAttribute(
-          t.jsxIdentifier('__native'),
-          t.jsxExpressionContainer(t.booleanLiteral(true))
-        )
-      );
+      componentInfo.nodes.forEach((node) => {
+        node.attributes.push(
+          t.jsxAttribute(
+            t.jsxIdentifier('__native'),
+            t.jsxExpressionContainer(t.booleanLiteral(true))
+          )
+        );
+      });
 
       // Generate a random tag name
       const replacedTagName = getTagName(tagName);


### PR DESCRIPTION
 
![image](https://user-images.githubusercontent.com/471003/96817646-62a84200-1452-11eb-969b-7d5f27200234.png)


code

```js
import NativeComponent from 'native-component';

export default function App() {
  return (
    <View>
      <NativeComponent />
      <NativeComponent />
    <View>
  )
}
```

expect

```html
<view>
  <native-component />
  <native-component />
</view>
```

actual

```html
<view>
  <native-component />
  <view class="h5-native-component" />
</view>
```