### PR TITLE
fix: createRef's function methods missing

### DIFF
--- a/packages/jsx2mp-runtime/src/createRef.js
+++ b/packages/jsx2mp-runtime/src/createRef.js
@@ -6,6 +6,8 @@ export default function(initialValue) {
   const ref = {
     current: initialValue
   };
+  ref.__proto__ = Function.prototype;
+
   const refFn = (instance, immobile) => {
     // Instance maybe component instance or triggered event object
     if (!created || !immobile) {


### PR DESCRIPTION
Add RefFn function prototype to fix "n.apply is not a function" in Ali mini app 