### PR TITLE
Release/jsx2mp 0.4.17

### DIFF
--- a/packages/jsx-compiler/package.json
+++ b/packages/jsx-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx-compiler",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "license": "BSD-3-Clause",
   "description": "Parser for Rax JSX Statements.",
   "files": [

--- a/packages/jsx-compiler/src/modules/code.js
+++ b/packages/jsx-compiler/src/modules/code.js
@@ -6,8 +6,7 @@ const isClassComponent = require('../utils/isClassComponent');
 const isFunctionComponent = require('../utils/isFunctionComponent');
 const traverse = require('../utils/traverseNodePath');
 const { isNpmModule, isWeexModule } = require('../utils/checkModule');
-const { getNpmName, normalizeFileName, addRelativePathPrefix, normalizeOutputFilePath } = require('../utils/pathHelper');
-const { BINDING_REG } = require('../utils/checkAttr');
+const { getNpmName, normalizeFileName, addRelativePathPrefix, normalizeOutputFilePath, SCRIPT_FILE_EXTENSIONS } = require('../utils/pathHelper');
 
 const RAX_PACKAGE = 'rax';
 const SUPER_COMPONENT = 'Component';
@@ -584,7 +583,7 @@ function addRegisterRefs(refs, renderFunctionPath) {
  */
 function ensureIndexInPath(value, resourcePath) {
   const target = resolveModule.sync(resolve(dirname(resourcePath), value), {
-    extensions: ['.js', '.ts', '.jsx', '.tsx']
+    extensions: SCRIPT_FILE_EXTENSIONS
   });
   const result = relative(dirname(resourcePath), target);
   return removeJSExtension(addRelativePathPrefix(normalizeOutputFilePath(result)));
@@ -592,7 +591,7 @@ function ensureIndexInPath(value, resourcePath) {
 
 function removeJSExtension(filePath) {
   const ext = extname(filePath);
-  if (ext === '.js' || ext === '.ts') {
+  if (SCRIPT_FILE_EXTENSIONS.indexOf(ext) > -1) {
     return filePath.slice(0, filePath.length - ext.length);
   }
   return filePath;

--- a/packages/jsx-compiler/src/modules/components.js
+++ b/packages/jsx-compiler/src/modules/components.js
@@ -11,7 +11,7 @@ const createBinding = require('../utils/createBinding');
 const Expression = require('../utils/Expression');
 const getCompiledComponents = require('../getCompiledComponents');
 const replaceComponentTagName = require('../utils/replaceComponentTagName');
-const { getNpmName, normalizeFileName, addRelativePathPrefix, normalizeOutputFilePath } = require('../utils/pathHelper');
+const { getNpmName, normalizeFileName, addRelativePathPrefix, normalizeOutputFilePath, SCRIPT_FILE_EXTENSIONS } = require('../utils/pathHelper');
 const { RELATIVE_COMPONENTS_REG, MINIAPP_PLUGIN_COMPONENTS_REG, PKG_NAME_REG, GROUP_PKG_NAME_REG} = require('../constants');
 
 let tagCount = 0;
@@ -356,9 +356,7 @@ function getComponentPath(alias, options) {
       throw new Error('`resourcePath` must be passed to calc dependency path.');
     }
 
-    const filename = multipleModuleResolve(options.resourcePath, alias.from, [
-      '.jsx', '.js', '.tsx', '.ts'
-    ]);
+    const filename = multipleModuleResolve(options.resourcePath, alias.from, SCRIPT_FILE_EXTENSIONS);
     return filename;
   } else {
     const { disableCopyNpm } = options;

--- a/packages/jsx-compiler/src/utils/pathHelper.js
+++ b/packages/jsx-compiler/src/utils/pathHelper.js
@@ -1,5 +1,7 @@
 const { sep } = require('path');
 
+const SCRIPT_FILE_EXTENSIONS = ['.js', '.ts', '.jsx', '.tsx'];
+
 function getNpmName(value) {
   const isScopedNpm = /^_?@/.test(value);
   return value.split(sep).slice(0, isScopedNpm ? 2 : 1).join(sep);
@@ -42,5 +44,6 @@ module.exports = {
   normalizeFileName,
   addRelativePathPrefix,
   normalizeOutputFilePath,
-  normalizeLocalFilePath
+  normalizeLocalFilePath,
+  SCRIPT_FILE_EXTENSIONS
 };

--- a/packages/jsx2mp-runtime/package.json
+++ b/packages/jsx2mp-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx2mp-runtime",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "description": "Runtime for jsx2mp.",
   "miniprogram": ".",
   "files": [

--- a/packages/jsx2mp-runtime/package.json
+++ b/packages/jsx2mp-runtime/package.json
@@ -2,12 +2,7 @@
   "name": "jsx2mp-runtime",
   "version": "0.4.16",
   "description": "Runtime for jsx2mp.",
-  "miniprogram": {
-    "ali": "dist/jsx2mp-runtime.ali.esm.js",
-    "wechat": "dist/jsx2mp-runtime.wechat.esm.js",
-    "quickapp": "dist/jsx2mp-runtime.quickapp.esm.js",
-    "bytedance": "dist/jsx2mp-runtime.bytedance.esm.js"
-  },
+  "miniprogram": ".",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
- [x] jsx2mp-runtime 兼容微信小程序 npm 处理逻辑

- [x] 修复 jsx-compiler 无法处理 jsx/tsx 后缀文件的问题