### PR TITLE
feat(jsx2mp): support css modules (without className mixup)

### DIFF
--- a/packages/jsx-compiler/package.json
+++ b/packages/jsx-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx-compiler",
-  "version": "0.4.21",
+  "version": "0.4.22",
   "license": "BSD-3-Clause",
   "description": "Parser for Rax JSX Statements.",
   "files": [

--- a/packages/jsx-compiler/src/modules/__tests__/style.js
+++ b/packages/jsx-compiler/src/modules/__tests__/style.js
@@ -31,3 +31,41 @@ describe('Transform style', () => {
     expect(genDynamicValue(dynamicStyle)).toEqual(expectedDynamicValue);
   });
 });
+
+describe('Transform className if using CSS modules', () => {
+  it('should transform className props', () => {
+    const raw = '<Text className={styles.name}>hello</Text>';
+    const expected = '<Text className="name">hello</Text>';
+    const ast = parseExpression(raw);
+    _transform(ast, {
+      'rax-text': [
+        {
+          local: 'Text',
+          default: true,
+          namespace: false,
+          name: 'rax-text',
+          isCustomEl: false
+        }
+      ],
+      './index.module.css': [
+        {
+          local: 'styles',
+          default: true,
+          namespace: false,
+          name: 'c-ed5081',
+          isCustomEl: true
+        }
+      ],
+      '../../components/Logo': [
+        {
+          local: 'Logo',
+          default: true,
+          namespace: false,
+          name: 'c-d25621',
+          isCustomEl: true
+        }
+      ]
+    });
+    expect(genExpression(ast)).toEqual(expected);
+  });
+});

--- a/packages/jsx-compiler/src/modules/css.js
+++ b/packages/jsx-compiler/src/modules/css.js
@@ -36,7 +36,7 @@ module.exports = {
             rawPath,
             filename: resolvedPath,
             content: readFileSync(resolvedPath, 'utf-8'),
-            type: (isAnomyousImport || isCssModuleImport) ? 'cssFile' : 'cssObject',
+            type: isAnomyousImport || isCssModuleImport ? 'cssFile' : 'cssObject',
           });
           if (isAnomyousImport || isCssModuleImport) cssFileMap[rawPath] = true; // For removing import statement.
         }

--- a/packages/jsx-compiler/src/modules/css.js
+++ b/packages/jsx-compiler/src/modules/css.js
@@ -1,15 +1,19 @@
 const t = require('@babel/types');
 const { readFileSync } = require('fs-extra');
 const { moduleResolve } = require('../utils/moduleResolve');
+const { isFilenameCSS, isFilenameCSSModule } = require('../utils/pathHelper');
 const traverse = require('../utils/traverseNodePath');
 
 /**
  * Add and convert style file to result.
  * 1. convert `rem` directly to `rpx`
  * 2. if named imported:
- *    import styles from './style.css';
+ *    2.1 import styles from './style.css';
  *    ->
  *    Transform and generate style.css to style.css.js
+ *    2.2 import styles from './style.module.css'
+ *    ->
+ *    Transform rpx and generate same name css files
  * 3. if anoymous imported
  *    import './style.css';
  *    ->
@@ -27,13 +31,14 @@ module.exports = {
         const resolvedPath = moduleResolve(options.resourcePath, rawPath);
         if (resolvedPath) {
           const isAnomyousImport = imported[rawPath].length === 0;
+          const isCssModuleImport = isFilenameCSSModule(rawPath);
           parsed.cssFiles.push({
             rawPath,
             filename: resolvedPath,
             content: readFileSync(resolvedPath, 'utf-8'),
-            type: isAnomyousImport ? 'cssFile' : 'cssObject',
+            type: (isAnomyousImport || isCssModuleImport) ? 'cssFile' : 'cssObject',
           });
-          if (isAnomyousImport) cssFileMap[rawPath] = true; // For removing import statement.
+          if (isAnomyousImport || isCssModuleImport) cssFileMap[rawPath] = true; // For removing import statement.
         }
       }
     });
@@ -58,7 +63,3 @@ module.exports = {
     }
   }
 };
-
-function isFilenameCSS(path) {
-  return /\.(css|sass|less|scss|styl)$/i.test(path);
-}

--- a/packages/jsx-compiler/src/modules/style.js
+++ b/packages/jsx-compiler/src/modules/style.js
@@ -41,11 +41,11 @@ function transformStyle(ast, imported) {
         const { property }  = node.value.expression;
         // className={styles.home} => className="home"
         if (t.isIdentifier(property)) {
-          node.value = t.stringLiteral(property.name)
+          node.value = t.stringLiteral(property.name);
         }
         // className={styles['home-info']} => className="home-info"
         if (t.isStringLiteral(property)) {
-          node.value = t.stringLiteral(property.value)
+          node.value = t.stringLiteral(property.value);
         }
       }
     },

--- a/packages/jsx-compiler/src/modules/style.js
+++ b/packages/jsx-compiler/src/modules/style.js
@@ -5,15 +5,21 @@ const TEMPLATE_AST = 'templateAST';
 const DynamicBinding = require('../utils/DynamicBinding');
 const getListItem = require('../utils/getListItem');
 const isSlotScopeNode = require('../utils/isSlotScopeNode');
+const { isFilenameCSSModule } = require('../utils/pathHelper');
 
 /**
- * Transform style object.
+ * 1. Transform style object.
  *  input:  <view style={{width: 100}}/>
  *  output: <view style="{{_style0}}">
  *          var _style0 = { width: 100 };
  *          return { _style0 };
+ *
+ * 2. Transform className if using css modules
+ *   input:  <view className={styles.home} />
+ *   output: <view className="home" />
  */
-function transformStyle(ast) {
+function transformStyle(ast, imported) {
+  const isUsingCSSModules = Object.keys(imported).some(rawPath => isFilenameCSSModule(rawPath));
   const dynamicStyle = new DynamicBinding('_s');
   let useCreateStyle = false;
   traverse(ast, {
@@ -29,6 +35,18 @@ function transformStyle(ast) {
         // Record original expression
         node.value.__originalExpression = styleObjectExpression;
         useCreateStyle = true;
+      }
+
+      if (isUsingCSSModules && node.name.name === 'className' && t.isJSXExpressionContainer(node.value) && t.isMemberExpression(node.value.expression)) {
+        const { property }  = node.value.expression;
+        // className={styles.home} => className="home"
+        if (t.isIdentifier(property)) {
+          node.value = t.stringLiteral(property.name)
+        }
+        // className={styles['home-info']} => className="home-info"
+        if (t.isStringLiteral(property)) {
+          node.value = t.stringLiteral(property.value)
+        }
       }
     },
   });
@@ -48,7 +66,7 @@ function shouldReplace(path) {
 
 module.exports = {
   parse(parsed, code, options) {
-    const { useCreateStyle, dynamicStyle } = transformStyle(parsed[TEMPLATE_AST]);
+    const { useCreateStyle, dynamicStyle } = transformStyle(parsed[TEMPLATE_AST], parsed.imported);
     if (!parsed.useCreateStyle) {
       parsed.useCreateStyle = useCreateStyle;
     }

--- a/packages/jsx-compiler/src/modules/style.js
+++ b/packages/jsx-compiler/src/modules/style.js
@@ -18,7 +18,7 @@ const { isFilenameCSSModule } = require('../utils/pathHelper');
  *   input:  <view className={styles.home} />
  *   output: <view className="home" />
  */
-function transformStyle(ast, imported) {
+function transformStyle(ast, imported = {}) {
   const isUsingCSSModules = Object.keys(imported).some(rawPath => isFilenameCSSModule(rawPath));
   const dynamicStyle = new DynamicBinding('_s');
   let useCreateStyle = false;

--- a/packages/jsx-compiler/src/modules/style.js
+++ b/packages/jsx-compiler/src/modules/style.js
@@ -38,7 +38,7 @@ function transformStyle(ast, imported) {
       }
 
       if (isUsingCSSModules && node.name.name === 'className' && t.isJSXExpressionContainer(node.value) && t.isMemberExpression(node.value.expression)) {
-        const { property }  = node.value.expression;
+        const { property } = node.value.expression;
         // className={styles.home} => className="home"
         if (t.isIdentifier(property)) {
           node.value = t.stringLiteral(property.name);

--- a/packages/jsx-compiler/src/utils/pathHelper.js
+++ b/packages/jsx-compiler/src/utils/pathHelper.js
@@ -39,11 +39,29 @@ function normalizeLocalFilePath(filepath) {
   return filepath.replace(/\\|\//g, sep);
 }
 
+/**
+ *
+ * @param {string} path
+ */
+function isFilenameCSS(path) {
+  return /\.(css|sass|less|scss|styl)$/i.test(path);
+}
+
+/**
+ *
+ * @param {string} path
+ */
+function isFilenameCSSModule(path) {
+  return /\.module\.(css|sass|less|scss|styl)$/i.test(path);
+}
+
 module.exports = {
   getNpmName,
   normalizeFileName,
   addRelativePathPrefix,
   normalizeOutputFilePath,
   normalizeLocalFilePath,
+  isFilenameCSS,
+  isFilenameCSSModule,
   SCRIPT_FILE_EXTENSIONS
 };


### PR DESCRIPTION
支持在小程序编译时中使用 CSS Modules 的写法 (但不混淆 class 类名)

Input:

```js
import styles from './index.module.css';
// ...
<View className={styles.home} />
```

Output: 
```axml
<view class="home" />
```
