### PR TITLE
feat(jsx2mp): support idenfy variable derived from props

### DIFF
--- a/packages/jsx-compiler/src/modules/__tests__/element.js
+++ b/packages/jsx-compiler/src/modules/__tests__/element.js
@@ -74,8 +74,6 @@ describe('Transform JSXElement', () => {
       expect(code).toEqual('<View foo="{{bar}}">{{ bar }}</View>');
     });
 
-
-
     it('should handle literial types', () => {
       const sourceCode = `
         <View

--- a/packages/jsx-compiler/src/modules/__tests__/render-function.js
+++ b/packages/jsx-compiler/src/modules/__tests__/render-function.js
@@ -7,6 +7,8 @@ const adapter = require('../../adapter').ali;
 const createJSX = require('../../utils/createJSX');
 const createBinding = require('../../utils/createBinding');
 const genExpression = require('../../codegen/genExpression');
+const getDefaultComponentFunctionPath = require('../../utils/getDefaultComponentFunctionPath');
+
 
 describe('Render item function', () => {
   it('should transform this.renderItem function', () => {
@@ -154,18 +156,4 @@ function getRenderMethodPath(path) {
   });
 
   return renderMethodPath;
-}
-
-function getDefaultComponentFunctionPath(path) {
-  let defaultComponentFunctionPath = null;
-  traverse(path, {
-    ExportDefaultDeclaration(exportDefaultPath) {
-      const declarationPath = exportDefaultPath.get('declaration');
-      if (declarationPath.isFunctionDeclaration()) {
-        defaultComponentFunctionPath = declarationPath;
-      }
-    }
-  });
-
-  return defaultComponentFunctionPath;
 }

--- a/packages/jsx-compiler/src/modules/__tests__/render-props.js
+++ b/packages/jsx-compiler/src/modules/__tests__/render-props.js
@@ -7,6 +7,7 @@ const adapter = require('../../adapter').ali;
 const createJSX = require('../../utils/createJSX');
 const createBinding = require('../../utils/createBinding');
 const genExpression = require('../../codegen/genExpression');
+const getDefaultComponentFunctionPath = require('../../utils/getDefaultComponentFunctionPath');
 
 describe('Pass render props', () => {
   it('basic render props usage', () => {
@@ -112,18 +113,4 @@ function transformReturnPath(path) {
   return createJSX('block', {
     [adapter.if]: t.stringLiteral(createBinding('$ready')),
   }, [returnArgument]);
-}
-
-function getDefaultComponentFunctionPath(path) {
-  let defaultComponentFunctionPath = null;
-  traverse(path, {
-    ExportDefaultDeclaration(exportDefaultPath) {
-      const declarationPath = exportDefaultPath.get('declaration');
-      if (declarationPath.isFunctionDeclaration()) {
-        defaultComponentFunctionPath = declarationPath;
-      }
-    }
-  });
-
-  return defaultComponentFunctionPath;
 }

--- a/packages/jsx-compiler/src/utils/getDefaultComponentFunctionPath.js
+++ b/packages/jsx-compiler/src/utils/getDefaultComponentFunctionPath.js
@@ -12,4 +12,4 @@ module.exports = function getDefaultComponentFunctionPath(path) {
   });
 
   return defaultComponentFunctionPath;
-}
+};

--- a/packages/jsx-compiler/src/utils/getDefaultComponentFunctionPath.js
+++ b/packages/jsx-compiler/src/utils/getDefaultComponentFunctionPath.js
@@ -1,0 +1,15 @@
+const traverse = require('./traverseNodePath');
+
+module.exports = function getDefaultComponentFunctionPath(path) {
+  let defaultComponentFunctionPath = null;
+  traverse(path, {
+    ExportDefaultDeclaration(exportDefaultPath) {
+      const declarationPath = exportDefaultPath.get('declaration');
+      if (declarationPath.isFunctionDeclaration()) {
+        defaultComponentFunctionPath = declarationPath;
+      }
+    }
+  });
+
+  return defaultComponentFunctionPath;
+}


### PR DESCRIPTION
从 props 或 this.props 中解构出的变量也能识别到，然后不将其转换为绑定变量，以通过原生 props 更新机制更新子组件

Input: 
```js
const { name } = props;
return (<View>{name}</View>)
```

Before:
```xml
<view>{{_d0}}</view>
```

After:
```xml
<view>{{name}}</view>
```
