### PR TITLE
Release/jsx2mp 1112

### DIFF
--- a/packages/jsx-compiler/package.json
+++ b/packages/jsx-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx-compiler",
-  "version": "0.4.21",
+  "version": "0.4.22",
   "license": "BSD-3-Clause",
   "description": "Parser for Rax JSX Statements.",
   "files": [

--- a/packages/jsx-compiler/package.json
+++ b/packages/jsx-compiler/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --testPathIgnorePatterns=__modules__",
     "test:watch": "npm run test -- --watchAll"
   },
-  "homepage": "https://github.com/alibaba/rax#readme",
+  "homepage": "https://github.com/raxjs/miniapp#readme",
   "engine": {
     "node": ">=8"
   },

--- a/packages/jsx-compiler/src/modules/__tests__/style.js
+++ b/packages/jsx-compiler/src/modules/__tests__/style.js
@@ -31,3 +31,41 @@ describe('Transform style', () => {
     expect(genDynamicValue(dynamicStyle)).toEqual(expectedDynamicValue);
   });
 });
+
+describe('Transform className if using CSS modules', () => {
+  it('should transform className props', () => {
+    const raw = '<Text className={styles.name}>hello</Text>';
+    const expected = '<Text className="name">hello</Text>';
+    const ast = parseExpression(raw);
+    _transform(ast, {
+      'rax-text': [
+        {
+          local: 'Text',
+          default: true,
+          namespace: false,
+          name: 'rax-text',
+          isCustomEl: false
+        }
+      ],
+      './index.module.css': [
+        {
+          local: 'styles',
+          default: true,
+          namespace: false,
+          name: 'c-ed5081',
+          isCustomEl: true
+        }
+      ],
+      '../../components/Logo': [
+        {
+          local: 'Logo',
+          default: true,
+          namespace: false,
+          name: 'c-d25621',
+          isCustomEl: true
+        }
+      ]
+    });
+    expect(genExpression(ast)).toEqual(expected);
+  });
+});

--- a/packages/jsx-compiler/src/utils/pathHelper.js
+++ b/packages/jsx-compiler/src/utils/pathHelper.js
@@ -39,11 +39,29 @@ function normalizeLocalFilePath(filepath) {
   return filepath.replace(/\\|\//g, sep);
 }
 
+/**
+ *
+ * @param {string} path
+ */
+function isFilenameCSS(path) {
+  return /\.(css|sass|less|scss|styl)$/i.test(path);
+}
+
+/**
+ *
+ * @param {string} path
+ */
+function isFilenameCSSModule(path) {
+  return /\.module\.(css|sass|less|scss|styl)$/i.test(path);
+}
+
 module.exports = {
   getNpmName,
   normalizeFileName,
   addRelativePathPrefix,
   normalizeOutputFilePath,
   normalizeLocalFilePath,
+  isFilenameCSS,
+  isFilenameCSSModule,
   SCRIPT_FILE_EXTENSIONS
 };

--- a/packages/jsx2mp-cli/package.json
+++ b/packages/jsx2mp-cli/package.json
@@ -10,7 +10,7 @@
     "test": "jest",
     "test:watch": "npm run test -- --watchAll"
   },
-  "homepage": "https://github.com/alibaba/rax#readme",
+  "homepage": "https://github.com/raxjs/miniapp#readme",
   "engine": {
     "node": ">=8"
   },

--- a/packages/jsx2mp-cli/package.json
+++ b/packages/jsx2mp-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx2mp-cli",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "license": "BSD-3-Clause",
   "description": "A cli tool to transform Rax JSX based project to MiniApp.",
   "bin": {

--- a/packages/jsx2mp-cli/plugins/runtime.js
+++ b/packages/jsx2mp-cli/plugins/runtime.js
@@ -21,9 +21,8 @@ module.exports = class JSX2MPRuntimePlugin {
     compiler.hooks.emit.tapAsync(
       'JSX2MPRuntimePlugin',
       (compilation, callback) => {
-        const runtimeTargetPath = runtimePackageJSON.miniprogram && runtimePackageJSON.miniprogram[this.platform]
-          ? runtimePackageJSON.miniprogram[this.platform]
-          : runtimePackageJSON.main || 'index.js';
+        const runtimeTargetPath = `dist/jsx2mp-runtime.${this.platform}.esm.js`;
+
         const sourceFile = require.resolve(join(runtimePackagePath, runtimeTargetPath));
         const targetFile = join(compiler.outputPath, 'npm', runtime + '.js');
 

--- a/packages/miniapp-compile-config/package.json
+++ b/packages/miniapp-compile-config/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.6",
   "description": "miniapp compile project config",
   "author": "Rax Team",
-  "homepage": "https://github.com/alibaba/rax#readme",
+  "homepage": "https://github.com/raxjs/miniapp#readme",
   "license": "BSD-3-Clause",
   "main": "src/index.js",
   "directories": {
@@ -12,13 +12,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/raxjs/rax-scripts.git"
+    "url": "git+https://github.com/raxjs/miniapp.git"
   },
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "bugs": {
-    "url": "https://github.com/alibaba/rax/issues"
+    "url": "https://github.com/raxjs/miniapp/issues"
   },
   "peerDependencies": {
     "webpack": "^4.0.0"

--- a/packages/miniapp-compile-config/package.json
+++ b/packages/miniapp-compile-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miniapp-compile-config",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "miniapp compile project config",
   "author": "Rax Team",
   "homepage": "https://github.com/alibaba/rax#readme",

--- a/packages/miniapp-compile-config/src/plugins/CopyJsx2mpRuntime.js
+++ b/packages/miniapp-compile-config/src/plugins/CopyJsx2mpRuntime.js
@@ -42,10 +42,7 @@ module.exports = class JSX2MPRuntimePlugin {
           runtimePackageJSON = readJSONSync(runtimePackageJSONPath);
           runtimePackagePath = join(runtimePackageJSONPath, '..');
         }
-
-        const runtimeTargetPath = runtimePackageJSON.miniprogram && runtimePackageJSON.miniprogram[this.platform]
-          ? runtimePackageJSON.miniprogram[this.platform]
-          : runtimePackageJSON.main || 'index.js';
+        const runtimeTargetPath = `dist/jsx2mp-runtime.${this.platform}.esm.js`;
         const sourceFile = require.resolve(join(runtimePackagePath, runtimeTargetPath));
         const targetFile = join(this.outputPath, 'npm', runtime + '.js');
 

--- a/packages/miniapp-compile-config/src/setBaseConfig.js
+++ b/packages/miniapp-compile-config/src/setBaseConfig.js
@@ -124,14 +124,16 @@ module.exports = (
 
   chainConfig.resolve.mainFields.add('main').add('module');
 
-  chainConfig.externals([
-    function(ctx, request, callback) {
-      if (/\.(css|sass|scss|styl|less)$/.test(request)) {
-        return callback(null, `commonjs2 ${request}`);
-      }
-      callback();
-    },
-  ]);
+  chainConfig.externals(
+    [
+      function (ctx, request, callback) {
+        if (/\.(css|sass|scss|styl|less)$/.test(request)) {
+          return callback(null, `commonjs2 ${request}`);
+        }
+        callback();
+      },
+    ].concat(chainConfig.get('externals') || [])
+  );
 
   chainConfig.plugin('define').use(webpack.DefinePlugin, [
     {

--- a/packages/miniapp-compile-config/src/setBaseConfig.js
+++ b/packages/miniapp-compile-config/src/setBaseConfig.js
@@ -126,7 +126,7 @@ module.exports = (
 
   chainConfig.externals(
     [
-      function (ctx, request, callback) {
+      function(ctx, request, callback) {
         if (/\.(css|sass|scss|styl|less)$/.test(request)) {
           return callback(null, `commonjs2 ${request}`);
         }


### PR DESCRIPTION
- [x] 修复 webpack external 配置被覆盖导致 @weex 等依赖无法移除的 bug

- [x] 支持在小程序编译时中使用 CSS Modules 的写法 (但不混淆 class 类名)

- [x] 取消构建时对 jsx2mp-runtime package.json miniprogram 字段的依赖