### PR TITLE
fix: :root selector is not supported in wechat miniprogram

### DIFF
--- a/packages/rax-miniapp-runtime-webpack-plugin/src/generators/app.js
+++ b/packages/rax-miniapp-runtime-webpack-plugin/src/generators/app.js
@@ -2,7 +2,7 @@ const { resolve, extname } = require('path');
 const { readFileSync } = require('fs-extra');
 const ejs = require('ejs');
 const adapter = require('../adapter');
-const { MINIAPP } = require('../constants');
+const { MINIAPP, WECHAT_MINIPROGRAM } = require('../constants');
 const addFileToCompilation = require('../utils/addFileToCompilation');
 const getAssetPath = require('../utils/getAssetPath');
 const adjustCSS = require('../utils/adjustCSS');
@@ -41,7 +41,7 @@ function generateAppCSS(compilation, { target, command, rootDir }) {
   const defaultCSSTmpl = adjustCSS(readFileSync(
     resolve(rootDir, 'templates', 'default.css.ejs'),
     'utf-8'
-  ));
+  ), target === WECHAT_MINIPROGRAM);
   // Generate __rax-view and __rax-text style for rax compiled components
   const raxDefaultCSSTmpl = readFileSync(
     resolve(rootDir, 'templates', 'rax-default.css.ejs'),

--- a/packages/rax-miniapp-runtime-webpack-plugin/src/utils/adjustCSS.js
+++ b/packages/rax-miniapp-runtime-webpack-plugin/src/utils/adjustCSS.js
@@ -87,11 +87,31 @@ const replaceTagNamePlugin = postcss.plugin('replaceTagName', () => root => {
   });
 });
 
-module.exports = function(code) {
-  code = postcss([replaceTagNamePlugin]).process(code, {
+/**
+ * repalce :root -> page for wechat-miniprogram
+ */
+const replaceRootSelector = postcss.plugin('replaceRoot', () => {
+  return (root) => {
+    root.walkRules(function (rule) {
+      if (rule.selector === ':root') {
+        rule.selector = 'page';
+      }
+    });
+  };
+});
+
+module.exports = function (code, replaceRoot) {
+  const plugins = [replaceTagNamePlugin];
+
+  if (replaceRoot) {
+    plugins.push(replaceRootSelector);
+  }
+
+  code = postcss(plugins).process(code, {
     from: undefined, // Eliminate warning
     map: null,
   });
 
   return code.css;
 };
+

--- a/packages/rax-miniapp-runtime-webpack-plugin/src/utils/wrapChunks.js
+++ b/packages/rax-miniapp-runtime-webpack-plugin/src/utils/wrapChunks.js
@@ -2,6 +2,7 @@ const ModuleFilenameHelpers = require('webpack/lib/ModuleFilenameHelpers');
 const { RawSource, ConcatSource } = require('webpack-sources');
 const adjustCSS = require('../utils/adjustCSS');
 const adapter = require('../adapter');
+const { WECHAT_MINIPROGRAM } = require('../constants');
 
 const matchFile = (fileName, ext) =>
   ModuleFilenameHelpers.matchObject(
@@ -29,7 +30,7 @@ module.exports = function(compilation, chunks, target) {
         compilation.assets[
           `${fileName}.${adapter[target].css}`
         ] = new RawSource(
-          adjustCSS(compilation.assets[fileName].source())
+          adjustCSS(compilation.assets[fileName].source(),target === WECHAT_MINIPROGRAM)
         );
       }
     });


### PR DESCRIPTION
```css
:root {}   
```

to


```
page { }
```