### PR TITLE
fix(jsx2mp): can't get correct npm path

### DIFF
--- a/packages/jsx-compiler/package.json
+++ b/packages/jsx-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx-compiler",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "license": "BSD-3-Clause",
   "description": "Parser for Rax JSX Statements.",
   "files": [

--- a/packages/jsx-compiler/src/modules/code.js
+++ b/packages/jsx-compiler/src/modules/code.js
@@ -122,9 +122,7 @@ module.exports = {
     renameAppConfig(ast, sourcePath, resourcePath);
 
     if (!disableCopyNpm) {
-      const currentNodeModulePath = join(sourcePath, 'npm');
-      const npmRelativePath = relative(dirname(resourcePath), currentNodeModulePath);
-      renameNpmModules(ast, npmRelativePath, resourcePath, cwd);
+      renameNpmModules(ast, targetFileDir, outputPath, cwd);
     }
 
     if (type !== 'app') {
@@ -287,8 +285,8 @@ function ensureIndexPathInImports(ast, resourcePath) {
   });
 }
 
-function renameNpmModules(ast, npmRelativePath, filename, cwd) {
-  const source = (value, prefix, filename, rootContext) => {
+function renameNpmModules(ast, targetFileDir, outputPath, cwd) {
+  const source = (value, targetFileDir, outputPath, rootContext) => {
     const npmName = getNpmName(value);
     const nodeModulePath = join(rootContext, 'node_modules');
     const searchPaths = [nodeModulePath];
@@ -308,9 +306,9 @@ function renameNpmModules(ast, npmRelativePath, filename, cwd) {
 
     let ret;
     if (npmName === value) {
-      ret = join(prefix, realNpmName, modulePathSuffix);
+      ret = relative(targetFileDir, join(outputPath, 'npm', realNpmName, modulePathSuffix));
     } else {
-      ret = join(prefix, value.replace(npmName, realNpmName));
+      ret = relative(targetFileDir, join(outputPath, 'npm', value.replace(npmName, realNpmName)));
     }
     ret = addRelativePathPrefix(normalizeOutputFilePath(ret));
     // ret => '../npm/_ali/universal-toast/lib/index.js
@@ -324,7 +322,7 @@ function renameNpmModules(ast, npmRelativePath, filename, cwd) {
       if (isWeexModule(value)) {
         path.remove();
       } else if (isNpmModule(value)) {
-        path.node.source = source(value, npmRelativePath, filename, cwd);
+        path.node.source = source(value, targetFileDir, outputPath, cwd);
       }
     }
   });

--- a/packages/jsx-compiler/src/utils/getAliasCorrespondingValue.js
+++ b/packages/jsx-compiler/src/utils/getAliasCorrespondingValue.js
@@ -1,4 +1,5 @@
 const { join, isAbsolute, relative, dirname } = require('path');
+const { addRelativePathPrefix } = require('./pathHelper');
 
 const ALIAS_TYPE = {
   // react -> rax
@@ -38,11 +39,11 @@ function getAliasCorrespondingValue(aliasEntries = {}, value = '', resourcePath 
         replacedValue = aliasEntries[value];
         break;
       case ALIAS_TYPE.PATH:
-        replacedValue = relative(dirname(resourcePath), aliasEntries[value]);
+        replacedValue = addRelativePathPrefix(relative(dirname(resourcePath), aliasEntries[value]));
         break;
       case ALIAS_TYPE.COMPLEX_PATH:
         const realAbsolutePath = join(aliasEntries[correspondingAlias], value.replace(correspondingAlias, ''));
-        replacedValue = relative(dirname(resourcePath), realAbsolutePath);
+        replacedValue = addRelativePathPrefix(relative(dirname(resourcePath), realAbsolutePath));
         break;
     }
     return replacedValue;


### PR DESCRIPTION
- [x] 更新 npm 引用时的路径处理方式，修复组件工程中 miniapp-demo 存在时 npm 路径处理错误的问题