### PR TITLE
fix(jsx2mp): variables with default assignment should be transformed

### DIFF
--- a/packages/jsx-compiler/package.json
+++ b/packages/jsx-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx-compiler",
-  "version": "0.4.24",
+  "version": "0.4.25",
   "license": "BSD-3-Clause",
   "description": "Parser for Rax JSX Statements.",
   "files": [

--- a/packages/jsx-compiler/src/modules/__tests__/element.js
+++ b/packages/jsx-compiler/src/modules/__tests__/element.js
@@ -74,6 +74,26 @@ describe('Transform JSXElement', () => {
       expect(code).toEqual('<View foo="{{bar}}">{{ bar }}</View>');
     });
 
+    it('props identifier with default assignment', () => {
+      const sourceCode = '<View foo={bar}>{ bar }</View>';
+      const ast = parseExpression(sourceCode);
+      const functionComponentAst = parseCode(`
+      export default function Component(props) {
+        const { bar = true } = props;
+        return (<View foo={bar}>{ bar }</View>);
+      }
+      `);
+      const renderFunctionPath = getDefaultComponentFunctionPath(functionComponentAst);
+      const dynamicValue = new DynamicBinding('_d');
+      _transform({
+        templateAST: ast,
+        dynamicValue,
+        renderFunctionPath
+      }, adapter, sourceCode);
+      const code = genInlineCode(ast).code;
+      expect(code).toEqual('<View foo="{{_d0}}">{{ _d0 }}</View>');
+    });
+
     it('should handle literial types', () => {
       const sourceCode = `
         <View

--- a/packages/jsx-compiler/src/modules/element.js
+++ b/packages/jsx-compiler/src/modules/element.js
@@ -173,7 +173,7 @@ function transformTemplate(
               expression,
               dynamicValue,
               isDirective,
-              isDerivedFromProps(renderFunctionPath.scope, expression.name)
+              isDerivedFromProps(renderFunctionPath.scope, expression.name, true)
             );
             path.replaceWith(
               t.stringLiteral(createBinding(genExpression(replaceNode))),
@@ -189,7 +189,7 @@ function transformTemplate(
               expression,
               dynamicValue,
               isDirective,
-              isDerivedFromProps(renderFunctionPath.scope, expression.name)
+              isDerivedFromProps(renderFunctionPath.scope, expression.name, true)
             );
             path.replaceWith(createJSXBinding(genExpression(replaceNode)));
           }

--- a/packages/jsx-compiler/src/modules/element.js
+++ b/packages/jsx-compiler/src/modules/element.js
@@ -173,7 +173,7 @@ function transformTemplate(
               expression,
               dynamicValue,
               isDirective,
-              isDerivedFromProps(renderFunctionPath.scope, expression.name, true)
+              isDerivedFromProps(renderFunctionPath.scope, expression.name, { excludeAssignment: true, isRecursion: false })
             );
             path.replaceWith(
               t.stringLiteral(createBinding(genExpression(replaceNode))),
@@ -189,7 +189,7 @@ function transformTemplate(
               expression,
               dynamicValue,
               isDirective,
-              isDerivedFromProps(renderFunctionPath.scope, expression.name, true)
+              isDerivedFromProps(renderFunctionPath.scope, expression.name, { excludeAssignment: true, isRecursion: false })
             );
             path.replaceWith(createJSXBinding(genExpression(replaceNode)));
           }

--- a/packages/jsx-compiler/src/modules/render-props.js
+++ b/packages/jsx-compiler/src/modules/render-props.js
@@ -57,7 +57,7 @@ function transformRenderPropsFunction(ast, renderFunctionPath, code) {
         const { callee } = node;
         // Handle render props
         // e.g. this.props.renderCat()
-        if (t.isIdentifier(callee) && callee.name.startsWith('render') && isDerivedFromProps(renderFunctionPath.scope, callee.name)) {
+        if (t.isIdentifier(callee) && callee.name.startsWith('render') && isDerivedFromProps(renderFunctionPath.scope, callee.name, {})) {
           if (!path.parentPath.isJSXExpressionContainer()) {
             throw new CodeError(code, node, node.loc, 'render props can only be used in JSX expression container');
           }

--- a/packages/jsx-compiler/src/utils/isDerivedFromProps.js
+++ b/packages/jsx-compiler/src/utils/isDerivedFromProps.js
@@ -1,25 +1,50 @@
 const t = require('@babel/types');
 
+
+/**
+ * Check whether the bindingName has default assignment
+ * @param bindingPath
+ * @param bindingName
+ */
+function hasDefaultAssignment(bindingPath, bindingName) {
+
+  const id = bindingPath.get('id');
+  if (t.isObjectPattern(id)) {
+    const properties = id.get('properties');
+    for (let property of properties) {
+      if (t.isObjectProperty(property) && t.isIdentifier(property.node.key) && property.node.key.name === bindingName && t.isAssignmentPattern(property.node.value)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
 /**
  * Judge whether a variable is derived from props
  * @param scope
  * @param bindingName
+ * @param excludeAssignment If the variable has default assignment, then should not identify it
  */
-module.exports = function isDerivedFromProps(scope, bindingName) {
+module.exports = function isDerivedFromProps(scope, bindingName, excludeAssignment = false) {
   const binding = scope.getBinding(bindingName);
   if (binding && binding.path.isVariableDeclarator()) {
+    if (excludeAssignment) {
+      if (hasDefaultAssignment(binding.path, bindingName)) {
+        return false;
+      }
+    }
     const init = binding.path.get('init');
-    if (init.isMemberExpression()) {
+    if (init.isMemberExpression()) { // this.props
       const { object, property } = init.node;
       if (t.isThisExpression(object) && t.isIdentifier(property, { name: 'props' })) {
         return true;
       }
     }
-    if (init.isIdentifier()) {
+    if (init.isIdentifier()) {  // props
       if (init.node.name === 'props') {
         return true;
       }
-      return isDerivedFromProps(scope, init.node.name);
+      return isDerivedFromProps(scope, init.node.name, excludeAssignment);
     }
   }
   return false;

--- a/packages/jsx-compiler/src/utils/isDerivedFromProps.js
+++ b/packages/jsx-compiler/src/utils/isDerivedFromProps.js
@@ -17,13 +17,16 @@ function hasDefaultAssignment(bindingPath, bindingName) {
   }
   return false;
 }
+
 /**
  * Judge whether a variable is derived from props
- * @param scope
- * @param bindingName
- * @param excludeAssignment If the variable has default assignment, then should not identify it
+ * @param {object} scope
+ * @param {string} bindingName
+ * @param {object} options
+ * @param {object} options.excludeAssignment If set true, then should not identify the variable if the variable has default assignment
+ * @param isRecursion whether search varibales recursively
  */
-module.exports = function isDerivedFromProps(scope, bindingName, excludeAssignment = false) {
+module.exports = function isDerivedFromProps(scope, bindingName, { excludeAssignment = false, isRecursion = true }) {
   const binding = scope.getBinding(bindingName);
   if (binding && binding.path.isVariableDeclarator()) {
     if (excludeAssignment) {
@@ -42,7 +45,7 @@ module.exports = function isDerivedFromProps(scope, bindingName, excludeAssignme
       if (init.node.name === 'props') {
         return true;
       }
-      return isDerivedFromProps(scope, init.node.name, excludeAssignment);
+      return isRecursion ? isDerivedFromProps(scope, init.node.name, excludeAssignment) : false;
     }
   }
   return false;

--- a/packages/jsx-compiler/src/utils/isDerivedFromProps.js
+++ b/packages/jsx-compiler/src/utils/isDerivedFromProps.js
@@ -1,13 +1,11 @@
 const t = require('@babel/types');
 
-
 /**
  * Check whether the bindingName has default assignment
  * @param bindingPath
  * @param bindingName
  */
 function hasDefaultAssignment(bindingPath, bindingName) {
-
   const id = bindingPath.get('id');
   if (t.isObjectPattern(id)) {
     const properties = id.get('properties');
@@ -40,7 +38,7 @@ module.exports = function isDerivedFromProps(scope, bindingName, excludeAssignme
         return true;
       }
     }
-    if (init.isIdentifier()) {  // props
+    if (init.isIdentifier()) { // props
       if (init.node.name === 'props') {
         return true;
       }


### PR DESCRIPTION
- [x] 从 props 中解构出的变量存在默认赋值时，应将其转换为 data，否则默认赋值将失效
- [x] 从 props 中解构出的多层变量，应将其转换为 data，否则将不可用，例如下述示例中的 name
```js
const { family } = props;
const { name } = family;
```