### PR TITLE
Hotfix/jsx2mp 1125

### DIFF
--- a/packages/jsx-compiler/package.json
+++ b/packages/jsx-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx-compiler",
-  "version": "0.4.24",
+  "version": "0.4.25",
   "license": "BSD-3-Clause",
   "description": "Parser for Rax JSX Statements.",
   "files": [

--- a/packages/jsx-compiler/src/modules/__tests__/element.js
+++ b/packages/jsx-compiler/src/modules/__tests__/element.js
@@ -74,6 +74,26 @@ describe('Transform JSXElement', () => {
       expect(code).toEqual('<View foo="{{bar}}">{{ bar }}</View>');
     });
 
+    it('props identifier with default assignment', () => {
+      const sourceCode = '<View foo={bar}>{ bar }</View>';
+      const ast = parseExpression(sourceCode);
+      const functionComponentAst = parseCode(`
+      export default function Component(props) {
+        const { bar = true } = props;
+        return (<View foo={bar}>{ bar }</View>);
+      }
+      `);
+      const renderFunctionPath = getDefaultComponentFunctionPath(functionComponentAst);
+      const dynamicValue = new DynamicBinding('_d');
+      _transform({
+        templateAST: ast,
+        dynamicValue,
+        renderFunctionPath
+      }, adapter, sourceCode);
+      const code = genInlineCode(ast).code;
+      expect(code).toEqual('<View foo="{{_d0}}">{{ _d0 }}</View>');
+    });
+
     it('should handle literial types', () => {
       const sourceCode = `
         <View

--- a/packages/jsx-compiler/src/modules/element.js
+++ b/packages/jsx-compiler/src/modules/element.js
@@ -173,7 +173,7 @@ function transformTemplate(
               expression,
               dynamicValue,
               isDirective,
-              isDerivedFromProps(renderFunctionPath.scope, expression.name)
+              isDerivedFromProps(renderFunctionPath.scope, expression.name, { excludeAssignment: true, isRecursion: false })
             );
             path.replaceWith(
               t.stringLiteral(createBinding(genExpression(replaceNode))),
@@ -189,7 +189,7 @@ function transformTemplate(
               expression,
               dynamicValue,
               isDirective,
-              isDerivedFromProps(renderFunctionPath.scope, expression.name)
+              isDerivedFromProps(renderFunctionPath.scope, expression.name, { excludeAssignment: true, isRecursion: false })
             );
             path.replaceWith(createJSXBinding(genExpression(replaceNode)));
           }

--- a/packages/jsx-compiler/src/modules/render-props.js
+++ b/packages/jsx-compiler/src/modules/render-props.js
@@ -57,7 +57,7 @@ function transformRenderPropsFunction(ast, renderFunctionPath, code) {
         const { callee } = node;
         // Handle render props
         // e.g. this.props.renderCat()
-        if (t.isIdentifier(callee) && callee.name.startsWith('render') && isDerivedFromProps(renderFunctionPath.scope, callee.name)) {
+        if (t.isIdentifier(callee) && callee.name.startsWith('render') && isDerivedFromProps(renderFunctionPath.scope, callee.name, {})) {
           if (!path.parentPath.isJSXExpressionContainer()) {
             throw new CodeError(code, node, node.loc, 'render props can only be used in JSX expression container');
           }

--- a/packages/jsx-compiler/src/utils/isDerivedFromProps.js
+++ b/packages/jsx-compiler/src/utils/isDerivedFromProps.js
@@ -1,25 +1,51 @@
 const t = require('@babel/types');
 
 /**
- * Judge whether a variable is derived from props
- * @param scope
+ * Check whether the bindingName has default assignment
+ * @param bindingPath
  * @param bindingName
  */
-module.exports = function isDerivedFromProps(scope, bindingName) {
+function hasDefaultAssignment(bindingPath, bindingName) {
+  const id = bindingPath.get('id');
+  if (t.isObjectPattern(id)) {
+    const properties = id.get('properties');
+    for (let property of properties) {
+      if (t.isObjectProperty(property) && t.isIdentifier(property.node.key) && property.node.key.name === bindingName && t.isAssignmentPattern(property.node.value)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Judge whether a variable is derived from props
+ * @param {object} scope
+ * @param {string} bindingName
+ * @param {object} options
+ * @param {object} options.excludeAssignment If set true, then should not identify the variable if the variable has default assignment
+ * @param isRecursion whether search varibales recursively
+ */
+module.exports = function isDerivedFromProps(scope, bindingName, { excludeAssignment = false, isRecursion = true }) {
   const binding = scope.getBinding(bindingName);
   if (binding && binding.path.isVariableDeclarator()) {
+    if (excludeAssignment) {
+      if (hasDefaultAssignment(binding.path, bindingName)) {
+        return false;
+      }
+    }
     const init = binding.path.get('init');
-    if (init.isMemberExpression()) {
+    if (init.isMemberExpression()) { // this.props
       const { object, property } = init.node;
       if (t.isThisExpression(object) && t.isIdentifier(property, { name: 'props' })) {
         return true;
       }
     }
-    if (init.isIdentifier()) {
+    if (init.isIdentifier()) { // props
       if (init.node.name === 'props') {
         return true;
       }
-      return isDerivedFromProps(scope, init.node.name);
+      return isRecursion ? isDerivedFromProps(scope, init.node.name, excludeAssignment) : false;
     }
   }
   return false;

--- a/packages/jsx-compiler/src/utils/pathHelper.js
+++ b/packages/jsx-compiler/src/utils/pathHelper.js
@@ -1,6 +1,6 @@
 const { sep } = require('path');
 
-const SCRIPT_FILE_EXTENSIONS = ['.js', '.ts', '.jsx', '.tsx'];
+const SCRIPT_FILE_EXTENSIONS = ['.js', '.ts', '.jsx', '.tsx', '.json'];
 
 function getNpmName(value) {
   const isScopedNpm = /^_?@/.test(value);

--- a/packages/jsx2mp-loader/package.json
+++ b/packages/jsx2mp-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx2mp-loader",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "description": "",
   "files": [
     "src"

--- a/packages/jsx2mp-loader/src/script-loader.js
+++ b/packages/jsx2mp-loader/src/script-loader.js
@@ -27,10 +27,11 @@ module.exports = function scriptLoader(content) {
   const loaderOptions = getOptions(this);
   const { rootDir, disableCopyNpm, outputPath, mode, entryPath, platform, importedComponent = '', isRelativeMiniappComponent = false, aliasEntries, constantDir } = loaderOptions;
   const rootContext = this.rootContext;
+  const isJSON = isJSONFile(this.resourcePath);
   const isAppJSon = this.resourcePath === join(rootContext, 'src', 'app.json');
-  const isJSON = !isAppJSon && isJSONFile(this.resourcePath);
+  const isCommonJSON = isJSON && !isAppJSon;
 
-  const rawContent = isJSON ? content : readFileSync(this.resourcePath, 'utf-8');
+  const rawContent = isCommonJSON ? content : readFileSync(this.resourcePath, 'utf-8');
   const nodeModulesPathList = getNearestNodeModulesPath(rootContext, this.resourcePath);
   const currentNodeModulePath = nodeModulesPathList[nodeModulesPathList.length - 1];
   const rootNodeModulePath = join(rootContext, 'node_modules');
@@ -149,7 +150,7 @@ module.exports = function scriptLoader(content) {
 
   if (isFromNodeModule(this.resourcePath)) {
     if (disableCopyNpm) {
-      return isJSON ? '{}' : content;
+      return isCommonJSON ? '{}' : content;
     }
     const relativeNpmPath = relative(currentNodeModulePath, this.resourcePath);
     const npmFolderName = getNpmFolderName(relativeNpmPath);
@@ -245,15 +246,14 @@ module.exports = function scriptLoader(content) {
       generateDependencies(dependencies),
       content
     ].join('\n');
-  } else {
-    !isAppJSon && outputFile(rawContent, false);
-    return transformCode(
-      rawContent, mode,
-      [ require('@babel/plugin-proposal-class-properties') ]
-    ).code; // For normal js file, syntax like class properties can't be parsed without babel plugins
+  } else if (!isAppJSon) {
+    outputFile(rawContent, false);
   }
 
-  return isJSON ? '{}' : content;
+  return isJSON ? '{}' : transformCode(
+    rawContent, mode,
+    [ require('@babel/plugin-proposal-class-properties') ]
+  ).code; // For normal js file, syntax like class properties can't be parsed without babel plugins
 };
 
 /**


### PR DESCRIPTION
- [x]  从 props 中解构出的变量存在默认赋值时，应将其转换为 data，否则默认赋值将失效
- [x] 从 props 中解构出的多层变量，应将其转换为 data，否则将不可用
- [x] 修复使用 babel 编译纯 js 文件时未过滤 json 文件的 bug