### PR TITLE
fix(jsx2mp): use loader content as input instead of rawContent

### DIFF
--- a/packages/jsx2mp-loader/package.json
+++ b/packages/jsx2mp-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx2mp-loader",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "description": "",
   "files": [
     "src"

--- a/packages/jsx2mp-loader/src/script-loader.js
+++ b/packages/jsx2mp-loader/src/script-loader.js
@@ -251,7 +251,7 @@ module.exports = function scriptLoader(content) {
   }
 
   return isJSON ? '{}' : transformCode(
-    rawContent, mode,
+    content, mode,
     [ require('@babel/plugin-proposal-class-properties') ]
   ).code; // For normal js file, syntax like class properties can't be parsed without babel plugins
 };


### PR DESCRIPTION
- [x] 使用 loader content 处理 ts 文件