### PR TITLE
fix(jsx2mp): exclude app json file import

### DIFF
--- a/packages/jsx-compiler/package.json
+++ b/packages/jsx-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx-compiler",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "license": "BSD-3-Clause",
   "description": "Parser for Rax JSX Statements.",
   "files": [


### PR DESCRIPTION
- [x] 修复旧工程中 import app.json 时 AST 处理替换为 app.config.js 失败的问题