### PR TITLE
fix(jsx2mp): jsx-compiler bug

### DIFF
--- a/packages/jsx-compiler/src/codegen/genCode.js
+++ b/packages/jsx-compiler/src/codegen/genCode.js
@@ -2,7 +2,10 @@ const generate = require('@babel/generator').default;
 
 const generateOptions = {
   sourceFileName: '',
-  sourceMaps: true
+  sourceMaps: true,
+  jsescOption: {
+    minimal: true // To avoid Chinese characters escaped
+  }
 };
 
 /**
@@ -11,11 +14,7 @@ const generateOptions = {
  */
 function genCode(ast, options = {}) {
   options.sourceMaps = !options.turnOffSourceMap;
-  return generate(ast, Object.assign({
-    jsescOption: {
-      minimal: true // To avoid Chinese characters escaped
-    }
-  }, generateOptions, options));
+  return generate(ast, Object.assign({}, generateOptions, options));
 }
 
 module.exports = genCode;

--- a/packages/jsx-compiler/src/codegen/genCode.js
+++ b/packages/jsx-compiler/src/codegen/genCode.js
@@ -11,7 +11,11 @@ const generateOptions = {
  */
 function genCode(ast, options = {}) {
   options.sourceMaps = !options.turnOffSourceMap;
-  return generate(ast, Object.assign({}, generateOptions, options));
+  return generate(ast, Object.assign({
+    jsescOption: {
+      minimal: true // To avoid Chinese characters escaped
+    }
+  }, generateOptions, options));
 }
 
 module.exports = genCode;

--- a/packages/jsx-compiler/src/codegen/genExpression.js
+++ b/packages/jsx-compiler/src/codegen/genExpression.js
@@ -11,9 +11,8 @@ function generateExpression(expression, overridesOption = {}) {
     Object.assign({
       jsescOption: {
         minimal: true // To avoid Chinese characters escaped
-      },
-      overridesOption
-    })
+      }
+    }, overridesOption)
   );
   return code;
 }

--- a/packages/jsx-compiler/src/codegen/genExpression.js
+++ b/packages/jsx-compiler/src/codegen/genExpression.js
@@ -8,7 +8,12 @@ const generate = require('@babel/generator').default;
 function generateExpression(expression, overridesOption = {}) {
   const { code } = generate(
     expression,
-    overridesOption
+    Object.assign({
+      jsescOption: {
+        minimal: true // To avoid Chinese characters escaped
+      },
+      overridesOption
+    })
   );
   return code;
 }

--- a/packages/jsx-compiler/src/modules/__tests__/element.js
+++ b/packages/jsx-compiler/src/modules/__tests__/element.js
@@ -55,12 +55,12 @@ describe('Transform JSXElement', () => {
     });
 
     it('props identifier', () => {
-      const sourceCode = '<View foo={bar}>{ bar }</View>';
+      const sourceCode = '<View foo={bar} name={name}>{ bar } {age}</View>';
       const ast = parseExpression(sourceCode);
       const functionComponentAst = parseCode(`
       export default function Component(props) {
-        const { bar } = props;
-        return (<View foo={bar}>{ bar }</View>);
+        const { bar, data: { name, age = 20 } } = props;
+        return (<View foo={bar} name={name}>{ bar } {age}</View>);
       }
       `);
       const renderFunctionPath = getDefaultComponentFunctionPath(functionComponentAst);
@@ -71,7 +71,9 @@ describe('Transform JSXElement', () => {
         renderFunctionPath
       }, adapter, sourceCode);
       const code = genInlineCode(ast).code;
-      expect(code).toEqual('<View foo="{{bar}}">{{ bar }}</View>');
+      expect(code).toEqual('<View foo="{{bar}}" name="{{_d0}}">{{ bar }} {{ _d1 }}</View>');
+      expect(genDynamicValue(dynamicValue)).toEqual('{ _d0: name, _d1: age }');
+
     });
 
     it('props identifier with default assignment', () => {

--- a/packages/jsx-compiler/src/modules/__tests__/element.js
+++ b/packages/jsx-compiler/src/modules/__tests__/element.js
@@ -73,7 +73,6 @@ describe('Transform JSXElement', () => {
       const code = genInlineCode(ast).code;
       expect(code).toEqual('<View foo="{{bar}}" name="{{_d0}}">{{ bar }} {{ _d1 }}</View>');
       expect(genDynamicValue(dynamicValue)).toEqual('{ _d0: name, _d1: age }');
-
     });
 
     it('props identifier with default assignment', () => {

--- a/packages/jsx-compiler/src/modules/__tests__/element.js
+++ b/packages/jsx-compiler/src/modules/__tests__/element.js
@@ -105,6 +105,7 @@ describe('Transform JSXElement', () => {
           nil={null}
           regexp={/a-z/}
           tpl={\`hello world \${exp}\`}
+          chineseTpl={\`我是中文 \${chineseExp}\`}
         >{false}{'string'}{8}{}{undefined}{null}{/a-z/}</View>
       `;
       const ast = parseExpression(sourceCode);
@@ -114,9 +115,9 @@ describe('Transform JSXElement', () => {
         dynamicValue
       }, adapter, sourceCode);
 
-      expect(genInlineCode(ast).code).toEqual('<View bool="{{true}}" str=\'string\' num="{{8}}" nil="{{null}}" regexp="{{_d0}}" tpl="hello world {{_d1}}">string8{{ _d0 }}</View>');
+      expect(genInlineCode(ast).code).toEqual('<View bool="{{true}}" str=\'string\' num="{{8}}" nil="{{null}}" regexp="{{_d0}}" tpl="hello world {{_d1}}" chineseTpl="我是中文 {{_d2}}">string8{{ _d0 }}</View>');
 
-      expect(genDynamicValue(dynamicValue)).toEqual('{ _d0: /a-z/, _d1: exp }');
+      expect(genDynamicValue(dynamicValue)).toEqual('{ _d0: /a-z/, _d1: exp, _d2: chineseExp }');
     });
 
     it('should handle expression types', () => {

--- a/packages/jsx-compiler/src/modules/element.js
+++ b/packages/jsx-compiler/src/modules/element.js
@@ -712,7 +712,7 @@ function transformIdentifier(expression, dynamicBinding, { isDirective, isDerive
     expression.__listItem && !expression.__listItem.item
     || expression.__templateVar
     || expression.__slotScope
-    || (!needRegisterProps && isDerivedFromProps)
+    || !needRegisterProps && isDerivedFromProps
   ) {
     // The identifier is x-for args or template variable or map's index or variable derived from props
     replaceNode = expression;

--- a/packages/jsx-compiler/src/modules/element.js
+++ b/packages/jsx-compiler/src/modules/element.js
@@ -172,8 +172,11 @@ function transformTemplate(
             const replaceNode = transformIdentifier(
               expression,
               dynamicValue,
-              isDirective,
-              isDerivedFromProps(renderFunctionPath.scope, expression.name, { excludeAssignment: true, isRecursion: false })
+              {
+                isDirective,
+                isDerivedFromProps: isDerivedFromProps(renderFunctionPath.scope, expression.name, { excludeAssignment: true, isRecursion: false }),
+                needRegisterProps: adapter.needRegisterProps
+              }
             );
             path.replaceWith(
               t.stringLiteral(createBinding(genExpression(replaceNode))),
@@ -188,8 +191,11 @@ function transformTemplate(
             const replaceNode = transformIdentifier(
               expression,
               dynamicValue,
-              isDirective,
-              isDerivedFromProps(renderFunctionPath.scope, expression.name, { excludeAssignment: true, isRecursion: false })
+              {
+                isDirective,
+                isDerivedFromProps: isDerivedFromProps(renderFunctionPath.scope, expression.name, { excludeAssignment: true, isRecursion: false }),
+                needRegisterProps: adapter.needRegisterProps
+              }
             );
             path.replaceWith(createJSXBinding(genExpression(replaceNode)));
           }
@@ -409,7 +415,7 @@ function transformTemplate(
               const replaceNode = transformIdentifier(
                 innerPath.node,
                 dynamicValue,
-                isDirective,
+                { isDirective }
               );
               replaceNode.__transformed = true;
               innerPath.replaceWith(replaceNode);
@@ -671,7 +677,7 @@ function transformMemberExpression(expression, dynamicBinding, options, isRecurs
           propertyReplaceNode = transformIdentifier(
             property,
             dynamicBinding,
-            isDirective,
+            { isDirective }
           );
           break;
         case 'MemberExpression':
@@ -700,13 +706,13 @@ function transformMemberExpression(expression, dynamicBinding, options, isRecurs
 /**
  * Transform Identifier
  * */
-function transformIdentifier(expression, dynamicBinding, isDirective, isDerivedFromProps) {
+function transformIdentifier(expression, dynamicBinding, { isDirective, isDerivedFromProps, needRegisterProps }) {
   let replaceNode;
   if (
     expression.__listItem && !expression.__listItem.item
     || expression.__templateVar
     || expression.__slotScope
-    || isDerivedFromProps
+    || (!needRegisterProps && isDerivedFromProps)
   ) {
     // The identifier is x-for args or template variable or map's index or variable derived from props
     replaceNode = expression;
@@ -735,7 +741,7 @@ function transformObjectExpression(expression, dynamicBinding, options) {
     const { key, value } = property;
     let replaceNode = value;
     if (t.isIdentifier(value)) {
-      replaceNode = transformIdentifier(value, dynamicBinding, options.isDirective);
+      replaceNode = transformIdentifier(value, dynamicBinding, options);
     }
     if (t.isMemberExpression(value)) {
       replaceNode = transformMemberExpression(
@@ -767,7 +773,7 @@ function transformCallExpressionArg(ast, params, dynamicValue, isDirective) {
     case 'Identifier':
       // Exclude the event object
       if (!params.some(param => param.name === ast.name)) {
-        ast = transformIdentifier(ast, dynamicValue, isDirective);
+        ast = transformIdentifier(ast, dynamicValue, { isDirective });
         ast.__dataset = true;
       }
       break;
@@ -779,7 +785,7 @@ function transformCallExpressionArg(ast, params, dynamicValue, isDirective) {
             if (!innerNode.__transformed) {
               // Exclude the event object
               if (!params.some(param => param.name === ast.name)) {
-                const replaceNode = transformIdentifier(innerNode, dynamicValue, isDirective);
+                const replaceNode = transformIdentifier(innerNode, dynamicValue, { isDirective });
                 innerPath.replaceWith(replaceNode);
               }
               innerPath.node.__transformed = true;

--- a/packages/jsx-compiler/src/utils/isDerivedFromProps.js
+++ b/packages/jsx-compiler/src/utils/isDerivedFromProps.js
@@ -1,16 +1,22 @@
 const t = require('@babel/types');
 
 /**
- * Check whether the bindingName has default assignment
- * @param bindingPath
- * @param bindingName
+ * Check whether the bindingName is the direct property of id
+ * @param {Object} bindingPath
+ * @param {string} bindingName
+ * @param {boolean} shouldHasDefaultAssignment - whether need the bindingName with default assignment
  */
-function hasDefaultAssignment(bindingPath, bindingName) {
+function checkDirectObjectProperty(bindingPath, bindingName, shouldHasDefaultAssignment) {
   const id = bindingPath.get('id');
   if (t.isObjectPattern(id)) {
     const properties = id.get('properties');
-    for (let property of properties) {
-      if (t.isObjectProperty(property) && t.isIdentifier(property.node.key) && property.node.key.name === bindingName && t.isAssignmentPattern(property.node.value)) {
+    for(let property of properties) {
+      const isDirectObjectPropery = t.isObjectProperty(property) && t.isIdentifier(property.node.key) && property.node.key.name === bindingName;
+      if (shouldHasDefaultAssignment) {
+        if (isDirectObjectPropery && t.isAssignmentPattern(property.node.value)) {
+          return true;
+        }
+      } else if (isDirectObjectPropery) {
         return true;
       }
     }
@@ -30,19 +36,20 @@ module.exports = function isDerivedFromProps(scope, bindingName, { excludeAssign
   const binding = scope.getBinding(bindingName);
   if (binding && binding.path.isVariableDeclarator()) {
     if (excludeAssignment) {
-      if (hasDefaultAssignment(binding.path, bindingName)) {
+      if (checkDirectObjectProperty(binding.path, bindingName, true)) {
         return false;
       }
     }
     const init = binding.path.get('init');
+
     if (init.isMemberExpression()) { // this.props
       const { object, property } = init.node;
-      if (t.isThisExpression(object) && t.isIdentifier(property, { name: 'props' })) {
+      if (t.isThisExpression(object) && t.isIdentifier(property, { name: 'props' }) && checkDirectObjectProperty(binding.path, bindingName, false)) {
         return true;
       }
     }
     if (init.isIdentifier()) { // props
-      if (init.node.name === 'props') {
+      if (init.node.name === 'props' && checkDirectObjectProperty(binding.path, bindingName, false)) {
         return true;
       }
       return isRecursion ? isDerivedFromProps(scope, init.node.name, excludeAssignment) : false;

--- a/packages/jsx-compiler/src/utils/isDerivedFromProps.js
+++ b/packages/jsx-compiler/src/utils/isDerivedFromProps.js
@@ -10,7 +10,7 @@ function checkDirectObjectProperty(bindingPath, bindingName, shouldHasDefaultAss
   const id = bindingPath.get('id');
   if (t.isObjectPattern(id)) {
     const properties = id.get('properties');
-    for(let property of properties) {
+    for (let property of properties) {
       const isDirectObjectPropery = t.isObjectProperty(property) && t.isIdentifier(property.node.key) && property.node.key.name === bindingName;
       if (shouldHasDefaultAssignment) {
         if (isDirectObjectPropery && t.isAssignmentPattern(property.node.value)) {


### PR DESCRIPTION
- [x] 修复判断变量是否派生自 props 及其是否需要转换为 data

如以下示例：

```js
const { person: { name, age = 20}, school, grade = 9 } = props;
```
其中只有 school 可以保留，其他变量均需要转换为 data

- [x] 微信端不判断变量是否派生自 props

- [x] 修复分包模式下 app.js 中因 css 文件路径被修改导致匿名引入和 css modules 引入语句无法被删除的问题


```js
// app.js
// 以下两句代码在产物中应当被删除
import './app.less';
import styles from './default.module.css';
```

- [x] 修复中文在模板中被 escape 的问题