### PR TITLE
feat: support miniapp share memory 

### DIFF
--- a/packages/miniapp-render/src/createConfig/app.js
+++ b/packages/miniapp-render/src/createConfig/app.js
@@ -5,7 +5,10 @@ import createDocument from '../document';
 import cache from '../utils/cache';
 
 export default function(init, config, packageName = '', nativeAppConfig = {}) {
-  cache.setConfig(config);
+  cache.setConfig({
+    ...config,
+    mainPackageName: packageName,
+  });
   const { onLaunch, onShow, onHide, onError, onPageNotFound, ...rest } = nativeAppConfig;
   const appConfig = {
     launched: isMiniApp,
@@ -98,10 +101,6 @@ export default function(init, config, packageName = '', nativeAppConfig = {}) {
           }
         });
       }
-    },
-    requireModule(target) {
-      if (isMiniApp) return;
-      return require(`${target}`);
     },
     ...rest
   };

--- a/packages/miniapp-render/src/window.js
+++ b/packages/miniapp-render/src/window.js
@@ -169,5 +169,12 @@ class Window extends EventTarget {
 }
 
 export default function createWindow() {
+  const { mainPackageName, subPackages } = cache.getConfig();
+  const { shareMemory } = subPackages || {};
+  if (mainPackageName === '' || !shareMemory) {
+    return new Window();
+  }
+  const mainPackageWindow = cache.getWindow(mainPackageName);
+  if (mainPackageWindow) return mainPackageWindow;
   return new Window();
 }

--- a/packages/rax-miniapp-config-webpack-plugin/src/index.js
+++ b/packages/rax-miniapp-config-webpack-plugin/src/index.js
@@ -32,6 +32,8 @@ module.exports = class MiniAppConfigPlugin {
           .filter(subAppConfig => !subAppConfig.miniappMain)
           .map(subAppConfig => transformAppConfig(outputPath, subAppConfig, target, subPackages));
 
+        config.subPackageBuildType = !!subPackages.shareMemory;
+
         // Transform main package pages
         const mainPackageConfig = subAppConfigList.filter(subAppConfig => subAppConfig.miniappMain)[0];
         config.pages = mainPackageConfig.pages;

--- a/packages/rax-miniapp-runtime-webpack-plugin/src/generators/config.js
+++ b/packages/rax-miniapp-runtime-webpack-plugin/src/generators/config.js
@@ -1,10 +1,11 @@
 const addFileToCompilation = require('../utils/addFileToCompilation');
 
-module.exports = function(compilation, { usingComponents, usingPlugins, pages, target, command }) {
+module.exports = function(compilation, { usingComponents, usingPlugins, pages, target, command, subPackages }) {
   const config = {
     usingComponents: {},
     usingPlugins: {},
-    pages
+    pages,
+    subPackages,
   };
 
   if (process.env.DEBUG === 'true') {

--- a/packages/rax-miniapp-runtime-webpack-plugin/src/generators/page.js
+++ b/packages/rax-miniapp-runtime-webpack-plugin/src/generators/page.js
@@ -42,8 +42,12 @@ function generatePageJS(
   const renderPath = getAssetPath('render', pageRoute);
   const route = getSepProcessedPath(pagePath);
   const nativeLifeCycles = `[${Object.keys(nativeLifeCyclesMap).reduce((total, current, index) => index === 0 ? `${total}'${current}'` : `${total},'${current}'`, '')}]`;
+  const requirePageBundle = commonPageJSFilePaths.reduce((prev, filePath) => {
+    if (filePath === 'webpack-runtime.js') return prev;
+    return `${prev}require('${getAssetPath(filePath, pageRoute)}')(window, document);`
+  }, '');
   const init = `
-function init(window, document) {${commonPageJSFilePaths.map(filePath => `require('${getAssetPath(filePath, pageRoute)}')(window, document)`).join(';')}}`;
+function init(window, document) {${requirePageBundle}}`;
 
   const pageJsContent = `
 const render = require('${renderPath}');

--- a/packages/rax-miniapp-runtime-webpack-plugin/src/index.js
+++ b/packages/rax-miniapp-runtime-webpack-plugin/src/index.js
@@ -142,7 +142,8 @@ class MiniAppRuntimePlugin {
           usingPlugins,
           pages,
           target,
-          command
+          command,
+          subPackages
         });
 
         // Only when developer may use native component, it will generate package.json in output


### PR DESCRIPTION
在共享内存的时候，每个分包的 window 将不再独立，而是共享同一个 window

```json
{
  "targets": [
    "miniapp",
    "wechat-miniprogram"
  ],
  "miniapp": {
    "subPackages": {
      "shareMemory": true
    }
  },
  "wechat-miniprogram": {
    "subPackages": {
      "shareMemory": true,
    }
  }
}
```