### PR TITLE
fix: miniapp vendor document toggle

### DIFF
--- a/packages/miniapp-render/CHANGELOG.md
+++ b/packages/miniapp-render/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Changed
 
+- add dispatch document modify callback
+
+## [2.2.3] - 2021-03-31
+
+### Changed
+
 - Share window when share memory in subpackages
 
 ## [2.2.2] - 2021-03-30

--- a/packages/miniapp-render/src/createConfig/app.js
+++ b/packages/miniapp-render/src/createConfig/app.js
@@ -102,8 +102,10 @@ export default function(init, config, packageName = '', nativeAppConfig = {}) {
         });
       }
     },
+    // document modify callback for override context's document
     __documentModifyCallbacks: [],
     _dispatchDocumentModify(val) {
+      // dispatch document modify when page toggle
       this.__documentModifyCallbacks.forEach(cb => {
         cb(val);
       });

--- a/packages/miniapp-render/src/createConfig/app.js
+++ b/packages/miniapp-render/src/createConfig/app.js
@@ -102,6 +102,12 @@ export default function(init, config, packageName = '', nativeAppConfig = {}) {
         });
       }
     },
+    __documentModifyCallbacks: [],
+    _dispatchDocumentModify(val) {
+      this.__documentModifyCallbacks.forEach(cb => {
+        cb(val)
+      });
+    },
     ...rest
   };
   if (isMiniApp) {

--- a/packages/miniapp-render/src/createConfig/app.js
+++ b/packages/miniapp-render/src/createConfig/app.js
@@ -105,7 +105,7 @@ export default function(init, config, packageName = '', nativeAppConfig = {}) {
     __documentModifyCallbacks: [],
     _dispatchDocumentModify(val) {
       this.__documentModifyCallbacks.forEach(cb => {
-        cb(val)
+        cb(val);
       });
     },
     ...rest

--- a/packages/rax-miniapp-runtime-webpack-plugin/CHANGELOG.md
+++ b/packages/rax-miniapp-runtime-webpack-plugin/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Changed
 
+- Add modify `document` callback front of wrapper chunk
+
+## [4.2.1] - 2021-03-31
+
+### Changed
+
 - Not require `webpack-runtime.js` in page js file
 
 ## [4.2.0] - 2021-03-30

--- a/packages/rax-miniapp-runtime-webpack-plugin/src/utils/wrapChunks.js
+++ b/packages/rax-miniapp-runtime-webpack-plugin/src/utils/wrapChunks.js
@@ -1,8 +1,6 @@
 const ModuleFilenameHelpers = require('webpack/lib/ModuleFilenameHelpers');
 const { RawSource, ConcatSource } = require('webpack-sources');
 const { platformMap } = require('miniapp-builder-shared');
-const { readFileSync } = require('fs-extra');
-const { resolve } = require('path');
 const adjustCSS = require('../utils/adjustCSS');
 const { UNRECURSIVE_TEMPLATE_TYPE } = require('../constants');
 
@@ -22,7 +20,15 @@ module.exports = function(compilation, chunks, target) {
         // Page js
         const headerContent =
 `${FunctionPolyfill}
-module.exports = function(window, document) {const HTMLElement = window["HTMLElement"];`;
+module.exports = function(window, document) {
+  const HTMLElement = window["HTMLElement"];
+  const documentModifyCallbacks = getApp().__documentModifyCallbacks;
+  if (Array.isArray(documentModifyCallbacks)) {
+    documentModifyCallbacks.push((val) => {
+      document = val;
+    });
+  }
+`;
 
         const footerContent = '}';
 


### PR DESCRIPTION
分包抽取 `vendor` 的情况下，每个 JS Bundle 外层包裹的 document 需要在页面切换的时候更新：

 ```js
module.exports = function(window, document) {
// 业务 bundle
}
```