### PR TITLE
feat: support custom scrollview

### DIFF
--- a/packages/miniapp-render/src/constants.js
+++ b/packages/miniapp-render/src/constants.js
@@ -32,3 +32,4 @@ export const CATCH_COMPONENTS = new Set(['view', 'h-element']); // With catchTou
 
 export const APPEAR_COMPONENT = 'view'; // Without appear event components
 
+export const ANCHOR_COMPONENT = 'scroll-view'; // Components which only use scrollIntoView to scroll

--- a/packages/miniapp-render/src/node/element.js
+++ b/packages/miniapp-render/src/node/element.js
@@ -1,6 +1,6 @@
 /* global CONTAINER */
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { isMiniApp } from 'universal-env';
+import { isMiniApp, isWeChatMiniProgram } from 'universal-env';
 import Node from './node';
 import ClassList from './class-list';
 import Style from './style';
@@ -8,7 +8,7 @@ import Attribute from './attribute';
 import cache from '../utils/cache';
 import { toDash } from '../utils/tool';
 import { simplifyDomTree, traverse } from '../utils/tree';
-import { BUILTIN_COMPONENT_LIST, STATIC_COMPONENTS, PURE_COMPONENTS, CATCH_COMPONENTS, APPEAR_COMPONENT } from '../constants';
+import { BUILTIN_COMPONENT_LIST, STATIC_COMPONENTS, PURE_COMPONENTS, CATCH_COMPONENTS, APPEAR_COMPONENT, ANCHOR_COMPONENT } from '../constants';
 
 class Element extends Node {
   constructor(options) {
@@ -94,6 +94,7 @@ class Element extends Node {
     const hasAppearEventBinded = this.__hasAppearEventBinded;
     const hasTouchEventBinded = this.__hasTouchEventBinded;
     const hasCatchTouchMoveFlag = this.__attrs.get('catchTouchMove');
+    const hasAnchorScrollFlag = this.__attrs.get('anchorScroll');
     const hasExtraAttribute = this.__hasExtraAttribute;
     const isPureComponent = PURE_COMPONENTS.has(this.__tmplName);
     if (!hasEventBinded) {
@@ -114,6 +115,9 @@ class Element extends Node {
 
     if (hasCatchTouchMoveFlag) {
       CATCH_COMPONENTS.has(this.__tmplName) && (nodeTypePrefix = 'catch-');
+    }
+    if (isWeChatMiniProgram && hasAnchorScrollFlag) {
+      ANCHOR_COMPONENT === this.__tmplName && (nodeTypePrefix = 'anchor-');
     }
     return `${nodeTypePrefix}${this.__tmplName}`;
   }

--- a/packages/rax-miniapp-runtime-webpack-plugin/src/platforms/wechat.js
+++ b/packages/rax-miniapp-runtime-webpack-plugin/src/platforms/wechat.js
@@ -163,6 +163,43 @@ const ScrollView = {
   basicEvents: {}
 };
 
+const AnchorScrollView = {
+  props: {
+    'scroll-x': 'false',
+    'scroll-y': 'false',
+    'upper-threshold': '50',
+    'lower-threshold': '50',
+    'scroll-into-view': '',
+    'scroll-with-animation': 'false',
+    'enable-back-to-top': 'false',
+    'enable-flex': 'false',
+    'scroll-anchoring': 'false',
+    'refresher-enabled': 'false',
+    'refresher-threshold': '45',
+    'refresher-default-style': addSingleQuote('black'),
+    'refresher-background': addSingleQuote('#FFF'),
+    'refresher-triggered': 'false',
+    enhanced: 'false',
+    bounces: 'true',
+    'show-scrollbar': 'true',
+    'paging-enabled': 'false',
+    'fast-deceleration': 'false',
+  },
+  events: {
+    DragStart: '',
+    Dragging: '',
+    DragEnd: '',
+    ScrollToUpper: '',
+    ScrollToLower: '',
+    Scroll: '',
+    RefresherPulling: '',
+    RefresherRefresh: '',
+    RefresherRestore: '',
+    RefresherAbort: ''
+  },
+  basicEvents: {}
+};
+
 const CoverView = {
   props: {
     'scroll-top': ''
@@ -828,6 +865,7 @@ exports.internalComponents = {
   Swiper,
   SwiperItem,
   ScrollView,
+  AnchorScrollView,
   CoverView,
   CoverImage,
   MovableView,
@@ -876,6 +914,7 @@ exports.derivedComponents = new Map([
   ['StaticView', 'View'],
   ['PureView', 'View'],
   ['NoTouchView', 'View'],
+  ['AnchorScrollView', 'ScrollView'],
   ['CatchHElement', 'View'],
   ['PureHElement', 'View'],
   ['NoTouchHElement', 'View'],
@@ -963,6 +1002,16 @@ exports.needModifyChildrenComponents = {
         <block>{{item.content}}</block>
       </block>
     </block>
+  `,
+  AnchorScrollView: children => `
+  <block wx:for="{{r.children}}" wx:key="nodeId">
+    <block wx:if="{{item.nodeId}}">
+      <template is="{{tool.c(item.nodeType, tool.d(c, 'anchor-scroll-view'))}}" data="{{r: item, c: tool.d(c, 'anchor-scroll-view'), cid: cid}}" />
+    </block>
+    <block wx:else>
+      <block>{{item.content}}</block>
+    </block>
+  </block>
   `,
   PickerView: children => `
     <picker-view-column wx:for="{{r.children}}" wx:key="nodeId" wx:if="{{item.nodeType !== 'h-comment'}}">


### PR DESCRIPTION
针对微信小程序端 scroll-view 中 scroll-top 和 scroll-left 可能影响 scroll-into-view 的问题，给出定制化的 scroll-view。用户在 rax-scrollview 或 scroll-view 上配置 anchorScroll 时即可启用无 scroll-top 和 scroll-left 的 scroll-view 模板