### PR TITLE
fix(miniapp): get target from event.currentTarget

### DIFF
--- a/packages/miniapp-render/src/bridge/createEventProxy.js
+++ b/packages/miniapp-render/src/bridge/createEventProxy.js
@@ -37,9 +37,9 @@ export default function() {
       const document = domNode.ownerDocument;
       if (document && document.__checkEvent(evt)) {
         if (isMiniApp) {
-          this.callEvent(eventName, evt, extra, evt.target.targetDataset.privateNodeId); // Default Left button
+          this.callEvent(eventName, evt, extra, evt.target.targetDataset.privateNodeId);
         } else {
-          this.callEvent(eventName, evt, extra, evt.target.dataset.privateNodeId); // Default Left button
+          this.callEvent(eventName, evt, extra, evt.target.dataset.privateNodeId);
         }
       }
     };

--- a/packages/miniapp-render/src/bridge/createEventProxy.js
+++ b/packages/miniapp-render/src/bridge/createEventProxy.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { isWeChatMiniProgram } from 'universal-env';
+import { isMiniApp, isWeChatMiniProgram } from 'universal-env';
 import getDomNodeFromEvt from './events/getDomNodeFromEvt';
 import baseEvents from './events/baseEvents';
 import { handlesMap } from '../builtInComponents';
@@ -36,7 +36,11 @@ export default function() {
       const domNode = this.getDomNodeFromEvt(evt);
       const document = domNode.ownerDocument;
       if (document && document.__checkEvent(evt)) {
-        this.callEvent(eventName, evt, extra, evt.target.dataset.privateNodeId); // Default Left button
+        if (isMiniApp) {
+          this.callEvent(eventName, evt, extra, evt.target.targetDataset.privateNodeId); // Default Left button
+        } else {
+          this.callEvent(eventName, evt, extra, evt.target.dataset.privateNodeId); // Default Left button
+        }
       }
     };
   });

--- a/packages/miniapp-render/src/bridge/createEventProxy.js
+++ b/packages/miniapp-render/src/bridge/createEventProxy.js
@@ -36,7 +36,7 @@ export default function() {
       const domNode = this.getDomNodeFromEvt(evt);
       const document = domNode.ownerDocument;
       if (document && document.__checkEvent(evt)) {
-        this.callEvent(eventName, evt, extra, evt.currentTarget.dataset.privateNodeId); // Default Left button
+        this.callEvent(eventName, evt, extra, evt.target.dataset.privateNodeId); // Default Left button
       }
     };
   });


### PR DESCRIPTION
- [x] fix: 修复从基本事件参数 event 中获取 target 时误从 currentTarget 取值，导致表现与 web 不一致的问题