### PR TITLE
fix(miniapp): miss marker-id and slot in cover-view

### DIFF
--- a/packages/rax-miniapp-runtime-webpack-plugin/src/platforms/wechat.js
+++ b/packages/rax-miniapp-runtime-webpack-plugin/src/platforms/wechat.js
@@ -202,7 +202,9 @@ const AnchorScrollView = {
 
 const CoverView = {
   props: {
-    'scroll-top': ''
+    'scroll-top': '',
+    'marker-id': '',
+    slot: ''
   },
   basicEvents: {
     ...tapEvents


### PR DESCRIPTION
- [x] 支持 map 中使用 cover-view 定制 callout 