### PR TITLE
feat(miniapp): support add props for component template

### DIFF
--- a/packages/rax-miniapp-runtime-webpack-plugin/src/generators/templates/baseTemplate.js
+++ b/packages/rax-miniapp-runtime-webpack-plugin/src/generators/templates/baseTemplate.js
@@ -174,13 +174,15 @@ function createMiniComponents(components, derivedComponents, adapter) {
 /**
  * Apply the custom component config
  * @param {Object} internalComponents
- * @param {Object} customComponentsConfig - Configed by developer using build script plugin
+ * @param {Object} customComponentsConfig - Configured by developer using build script plugin
  */
 function modifyInternalComponents(internalComponents, customComponentsConfig) {
   const result = Object.assign({}, internalComponents);
   Object.keys(customComponentsConfig).forEach(comp => {
     const componentConfig = customComponentsConfig[comp];
-    const { 'delete': { props = [], events = [] } } = componentConfig; // Only support deleting temporarily
+    const { add: added = {}, 'delete': deleted = {}} = componentConfig;
+    const { props = [], events = [] } = deleted;
+    const { props: addedProps = [] } = added;
     const camelCasedCompName = toCamel(comp);
     if (result[camelCasedCompName]) {
       props.forEach(prop => delete result[camelCasedCompName].props[prop]);
@@ -189,6 +191,13 @@ function modifyInternalComponents(internalComponents, customComponentsConfig) {
           delete result[camelCasedCompName].basicEvents[event];
         } else if (result[camelCasedCompName].events && result[camelCasedCompName].events[event] !== undefined) {
           delete result[camelCasedCompName].events[event];
+        }
+      });
+      addedProps.forEach(prop => {
+        // Make sure the prop to be added doesn't exist at start
+        if (!result[camelCasedCompName].props[prop]) {
+          const defaultValue = prop.default === undefined ? '' : typeof prop.default === 'string' ? addSingleQuote(prop.default) : JSON.stringify(prop.default);
+          result[camelCasedCompName].props[prop.name] = defaultValue;
         }
       });
     }


### PR DESCRIPTION
feat: 运行时小程序支持用户在 `build.json` 中对某组件增加默认属性配置，示例方式如下：

```json
  "miniapp": {
    "template": {
      "cover-view": {
        "add": {
          "props": [
            {
              "name": "test1",
              "default": "232"
            },
            {
              "name": "test2",
              "default": 233
            },
            {
              "name": "test3",
              "default": false
            }
          ]
        }
      }
    }
  }
```