### PR TITLE
[WIP]feat(miniapp): make event compatible when element is destroyed

### DIFF
--- a/packages/miniapp-render/src/event/event-target.js
+++ b/packages/miniapp-render/src/event/event-target.js
@@ -92,10 +92,10 @@ class EventTarget {
   // Destroy instance
   _destroy() {
     this.__miniappEvent = null;
-    this.__eventHandlerMap = null;
     this.__hasEventBinded = null;
     this.__hasTouchEventBinded = null;
     this.__hasAppearEventBinded = false;
+    this.__eventHandlerMap.clear();
   }
 
   // Trigger event capture, bubble flow


### PR DESCRIPTION
- [x] 兼容节点销毁后事件系统无法获取 event bus 导致 js 报错的场景 