### PR TITLE
feat(miniapp): move js bundle execution time to app onLaunch in wechat

### DIFF
--- a/packages/miniapp-render/src/constants.js
+++ b/packages/miniapp-render/src/constants.js
@@ -24,6 +24,8 @@ export const BUILTIN_COMPONENT_LIST = new Set([
 
 export const BODY_NODE_ID = 'e-body';
 
+export const INDEX_PAGE = 'index-page';
+
 export const STATIC_COMPONENTS = new Set(['view', 'text', 'image']); // With no events components
 
 export const PURE_COMPONENTS = new Set(['view', 'h-element']); // With no events or props && equal to TOUCH_COMPONENTS

--- a/packages/miniapp-render/src/createConfig/app.js
+++ b/packages/miniapp-render/src/createConfig/app.js
@@ -21,6 +21,7 @@ export default function(init, config, packageName = '', nativeAppConfig = {}) {
       // `getCurrentPages()` can get the first page in app onLaunch in the following situation:
       // 1. In alibaba miniapp
       // 2. The first page is not from plugin
+      // eslint-disable-next-line no-undef
       const currentPageId = getCurrentPages()[0] ? `${getCurrentPages()[0].route}-1` : INDEX_PAGE;
       const currentDocument = createDocument(currentPageId);
       this.__pageId = window.__pageId = currentPageId;

--- a/packages/miniapp-render/src/createConfig/app.js
+++ b/packages/miniapp-render/src/createConfig/app.js
@@ -18,9 +18,10 @@ export default function(init, config, packageName = '', nativeAppConfig = {}) {
 
       const window = createWindow();
       cache.setWindow(packageName, window);
-      // Only in alibaba miniapp `getCurrentPages()` can get the first page in app onLaunch
-      // eslint-disable-next-line no-undef
-      const currentPageId = isMiniApp ? `${getCurrentPages()[0].route}-1` : INDEX_PAGE;
+      // `getCurrentPages()` can get the first page in app onLaunch in the following situation:
+      // 1. In alibaba miniapp
+      // 2. The first page is not from plugin
+      const currentPageId = getCurrentPages()[0] ? `${getCurrentPages()[0].route}-1` : INDEX_PAGE;
       const currentDocument = createDocument(currentPageId);
       this.__pageId = window.__pageId = currentPageId;
 

--- a/packages/miniapp-render/src/createConfig/page.js
+++ b/packages/miniapp-render/src/createConfig/page.js
@@ -15,7 +15,7 @@ export function getBaseLifeCycles(route, init, packageName = '') {
       const app = getApp();
 
       this.pageId = route + '-' + cache.getRouteId(route);
-      // In non alibaba miniapp, pageId is set to 'home-page' in app onLaunch
+      // In non alibaba miniapp or the first page is from plugin, pageId is set to 'home-page' in app onLaunch
       if (app.__pageId === INDEX_PAGE) {
         this.document = cache.getDocument(INDEX_PAGE);
         this.document._switchPageId(this.pageId);

--- a/packages/miniapp-render/src/createConfig/page.js
+++ b/packages/miniapp-render/src/createConfig/page.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { isMiniApp, isWeChatMiniProgram } from 'universal-env';
+import { isWeChatMiniProgram } from 'universal-env';
 
 import cache from '../utils/cache';
 import injectLifeCycle from '../bridge/injectLifeCycle';
@@ -11,19 +11,24 @@ import createWindow from '../window';
 export function getBaseLifeCycles(route, init, packageName = '') {
   return {
     onLoad(query) {
-      // eslint-disable-next-line no-undef
-      const app = getApp();
-
       this.pageId = route + '-' + cache.getRouteId(route);
-      // In non alibaba miniapp or the first page is from plugin, pageId is set to 'home-page' in app onLaunch
-      if (app.__pageId === INDEX_PAGE) {
-        this.document = cache.getDocument(INDEX_PAGE);
-        this.document._switchPageId(this.pageId);
-        cache.destroy(INDEX_PAGE);
-        cache.init(this.pageId, this.document);
-        app.__pageId = this.pageId;
-      } else if (this.pageId === app.__pageId) {
-        this.document = cache.getDocument(this.pageId);
+      // getApp may not exist in situations like plugin project
+      // eslint-disable-next-line no-undef
+      if (typeof getApp === 'function') {
+        // eslint-disable-next-line no-undef
+        const app = getApp();
+        // In non alibaba miniapp or the first page is from plugin, pageId is set to 'home-page' in app onLaunch
+        if (app.__pageId === INDEX_PAGE) {
+          this.document = cache.getDocument(INDEX_PAGE);
+          this.document._switchPageId(this.pageId);
+          cache.destroy(INDEX_PAGE);
+          cache.init(this.pageId, this.document);
+          app.__pageId = this.pageId;
+        } else if (this.pageId === app.__pageId) {
+          this.document = cache.getDocument(this.pageId);
+        } else {
+          this.document = createDocument(this.pageId);
+        }
       } else {
         this.document = createDocument(this.pageId);
       }

--- a/packages/miniapp-render/src/document.js
+++ b/packages/miniapp-render/src/document.js
@@ -73,6 +73,12 @@ class Document extends EventTarget {
     }
   }
 
+  _switchPageId(pageId) {
+    this.__pageId = pageId;
+    const rootNodeId = `${BODY_NODE_ID}-${pageId}`;
+    cache.setNode(rootNodeId, this.__root);
+  }
+
   // Node type
   get nodeType() {
     return Node.DOCUMENT_NODE;
@@ -220,9 +226,7 @@ class Document extends EventTarget {
 export default function createDocument(pageId) {
   const document = new Document(pageId);
 
-  cache.init(pageId, {
-    document
-  });
+  cache.init(pageId, document);
 
   return document;
 };

--- a/packages/miniapp-render/src/node/attribute.js
+++ b/packages/miniapp-render/src/node/attribute.js
@@ -1,3 +1,5 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { isBaiduSmartProgram } from 'universal-env';
 import { toCamel } from '../utils/tool';
 
 class Attribute {
@@ -22,7 +24,7 @@ class Attribute {
       }
       if (element._isRendered()) {
         const payload = {
-          path: `${element._path}.${name}`,
+          path: isBaiduSmartProgram ? `${element._path}['${name}']` : `${element._path}.${name}`,
           value: value
         };
         element._triggerUpdate(payload, immediate);
@@ -76,7 +78,7 @@ class Attribute {
         delete element.dataset[datasetName];
       }
       const payload = {
-        path: `${element._path}.${name}`,
+        path: isBaiduSmartProgram ? `${element._path}['${name}']` : `${element._path}.${name}`,
         value: ''
       };
       element._triggerUpdate(payload);

--- a/packages/miniapp-render/src/node/attribute.js
+++ b/packages/miniapp-render/src/node/attribute.js
@@ -24,6 +24,8 @@ class Attribute {
       }
       if (element._isRendered()) {
         const payload = {
+          // In baidu smartprogram, setData path supports like: root.children.0['scroll-into-view']
+          // While in wechat miniprogram, the same setData path muse be: root.children.[0].scroll-into-view
           path: isBaiduSmartProgram ? `${element._path}['${name}']` : `${element._path}.${name}`,
           value: value
         };

--- a/packages/miniapp-render/src/utils/cache.js
+++ b/packages/miniapp-render/src/utils/cache.js
@@ -12,8 +12,8 @@ const pagesCache = [];
 const elementMethodsCache = new Map();
 
 // Init
-function init(pageId, options) {
-  pageMap[pageId] = options.document;
+function init(pageId, document) {
+  pageMap[pageId] = document;
 }
 
 // Destroy

--- a/packages/rax-miniapp-runtime-webpack-plugin/src/generators/app.js
+++ b/packages/rax-miniapp-runtime-webpack-plugin/src/generators/app.js
@@ -13,7 +13,7 @@ function generateAppJS(
   { target, command, withNativeAppConfig }
 ) {
   const init =
-`function init(window, document) {${commonAppJSFilePaths.map(filePath => `require('${getAssetPath(filePath, 'app.js')}')(window, document)`).join(';')}}`;
+`function init(window, document, app) {${commonAppJSFilePaths.map(filePath => `require('${getAssetPath(filePath, 'app.js')}')(window, document, app)`).join(';')}}`;
   const requireNativeAppConfig = withNativeAppConfig ? "const nativeAppConfig = require('./miniapp-native/app');" : 'const nativeAppConfig = {}';
   const appJsContent = `${requireNativeAppConfig}
 const render = require('./render');

--- a/packages/rax-miniapp-runtime-webpack-plugin/src/utils/wrapChunks.js
+++ b/packages/rax-miniapp-runtime-webpack-plugin/src/utils/wrapChunks.js
@@ -20,9 +20,9 @@ module.exports = function(compilation, chunks, target) {
         // Page js
         const headerContent =
 `${FunctionPolyfill}
-module.exports = function(window, document) {
+module.exports = function(window, document, app) {
   const HTMLElement = window["HTMLElement"];
-  const documentModifyCallbacks = getApp().__documentModifyCallbacks;
+  const documentModifyCallbacks = (getApp() || app).__documentModifyCallbacks;
   if (Array.isArray(documentModifyCallbacks)) {
     documentModifyCallbacks.push((val) => {
       document = val;


### PR DESCRIPTION
- [x] 将微信端的 JS bundle 执行时机调整为 app onLaunch，与支付宝小程序保持一致