### PR TITLE
feat(jsx2mp): make exports compatible

### DIFF
--- a/packages/jsx-compiler/CHANGELOG.md
+++ b/packages/jsx-compiler/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.4.31] - 2021-06-29
+
+### Changed
+
+- Use resolve to replace `require.resolve` to make exports field compatible
 
 ## [0.4.30] - 2021-03-30
 

--- a/packages/jsx-compiler/package.json
+++ b/packages/jsx-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx-compiler",
-  "version": "0.4.30",
+  "version": "0.4.31",
   "license": "BSD-3-Clause",
   "description": "Parser for Rax JSX Statements.",
   "files": [

--- a/packages/jsx-compiler/src/modules/code.js
+++ b/packages/jsx-compiler/src/modules/code.js
@@ -290,7 +290,8 @@ function renameNpmModules(ast, targetFileDir, outputPath, cwd) {
     const npmName = getNpmName(value);
     const nodeModulePath = join(rootContext, 'node_modules');
     const searchPaths = [nodeModulePath];
-    const target = require.resolve(npmName, { paths: searchPaths });
+    // Use resolve instead of require.resolve because require.resolve will read the exports field first, which is not expected
+    const target = resolveModule.sync(npmName, { paths: searchPaths, preserveSymlinks: false });
     // In tnpm, target will be like following (symbol linked path):
     // ***/_universal-toast_1.0.0_universal-toast/lib/index.js
     let packageJSONPath;

--- a/packages/jsx2mp-loader/CHANGELOG.md
+++ b/packages/jsx2mp-loader/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.4.27] - 2021-06-29
+
+### Changed
+
+- Use resolve to replace `require.resolve` to make exports field compatible
+
 ## [0.4.25] - 2021-05-19
 
 ### Chore

--- a/packages/jsx2mp-loader/package.json
+++ b/packages/jsx2mp-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx2mp-loader",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "description": "",
   "files": [
     "src"

--- a/packages/jsx2mp-loader/package.json
+++ b/packages/jsx2mp-loader/package.json
@@ -30,6 +30,7 @@
     "loader-utils": "^1.2.3",
     "miniapp-builder-shared": "^0.2.0",
     "pretty-data": "^0.40.0",
+    "resolve": "^1.20.0",
     "sass": "^1.23.2",
     "stylesheet-loader": "^0.9.0",
     "stylus": "^0.54.7",

--- a/packages/jsx2mp-loader/src/script-loader.js
+++ b/packages/jsx2mp-loader/src/script-loader.js
@@ -2,6 +2,7 @@ const { join, dirname, relative, resolve, sep, extname } = require('path');
 
 const { copySync, existsSync, mkdirpSync, ensureFileSync, writeJSONSync, readFileSync, readJSONSync } = require('fs-extra');
 const { getOptions } = require('loader-utils');
+const resolveModule = require('resolve');
 const { constants: { QUICKAPP }} = require('miniapp-builder-shared');
 const cached = require('./cached');
 const { removeExt, doubleBackslash, normalizeOutputFilePath, addRelativePathPrefix, isFromTargetDirs } = require('./utils/pathHelper');
@@ -122,9 +123,7 @@ module.exports = function scriptLoader(content) {
             const componentPath = componentConfig.usingComponents[key];
             if (isNpmModule(componentPath)) {
               // component from node module
-              const realComponentPath = require.resolve(componentPath, {
-                paths: [this.resourcePath]
-              });
+              const realComponentPath = resolveModule.sync(componentPath, { paths: [this.resourcePath], preserveSymlinks: false });
               const relativeComponentPath = normalizeNpmFileName(addRelativePathPrefix(relative(dirname(sourceNativeMiniappScriptFile), realComponentPath)));
               componentConfig.usingComponents[key] = normalizeOutputFilePath(removeExt(relativeComponentPath));
               // Native miniapp component js file will loaded by script-loader


### PR DESCRIPTION
- [x] Use resolve instead of require.resolve because require.resolve will read the exports field first, which is not expected