### PR TITLE
fix(jsx2mp): miss basedir config in resolve function

### DIFF
--- a/packages/jsx-compiler/CHANGELOG.md
+++ b/packages/jsx-compiler/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.4.32] - 2021-06-30
+
+### Fixed
+
+- Miss basedir config in resolve
+
 ## [0.4.31] - 2021-06-29
 
 ### Changed

--- a/packages/jsx-compiler/package.json
+++ b/packages/jsx-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx-compiler",
-  "version": "0.4.31",
+  "version": "0.4.32",
   "license": "BSD-3-Clause",
   "description": "Parser for Rax JSX Statements.",
   "files": [

--- a/packages/jsx-compiler/src/modules/code.js
+++ b/packages/jsx-compiler/src/modules/code.js
@@ -123,7 +123,7 @@ module.exports = {
     renameAppConfig(ast, sourcePath, resourcePath, type);
 
     if (!disableCopyNpm) {
-      renameNpmModules(ast, targetFileDir, outputPath, cwd);
+      renameNpmModules(ast, targetFileDir, outputPath, cwd, resourcePath);
     }
 
     if (type !== 'app') {
@@ -285,13 +285,13 @@ function ensureIndexPathInImports(ast, sourcePath, resourcePath, type) {
   });
 }
 
-function renameNpmModules(ast, targetFileDir, outputPath, cwd) {
+function renameNpmModules(ast, targetFileDir, outputPath, cwd, resourcePath) {
   const source = (value, targetFileDir, outputPath, rootContext) => {
     const npmName = getNpmName(value);
     const nodeModulePath = join(rootContext, 'node_modules');
     const searchPaths = [nodeModulePath];
     // Use resolve instead of require.resolve because require.resolve will read the exports field first, which is not expected
-    const target = resolveModule.sync(npmName, { paths: searchPaths, preserveSymlinks: false });
+    const target = resolveModule.sync(npmName, { basedir: dirname(resourcePath), paths: searchPaths, preserveSymlinks: false });
     // In tnpm, target will be like following (symbol linked path):
     // ***/_universal-toast_1.0.0_universal-toast/lib/index.js
     let packageJSONPath;

--- a/packages/jsx2mp-loader/CHANGELOG.md
+++ b/packages/jsx2mp-loader/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.4.28] - 2021-06-30
+
+### Fixed
+
+- Miss basedir config in resolve
+
 ## [0.4.27] - 2021-06-29
 
 ### Changed

--- a/packages/jsx2mp-loader/package.json
+++ b/packages/jsx2mp-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx2mp-loader",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "description": "",
   "files": [
     "src"

--- a/packages/jsx2mp-loader/src/script-loader.js
+++ b/packages/jsx2mp-loader/src/script-loader.js
@@ -13,6 +13,8 @@ const { output, transformCode } = require('./output');
 
 const ScriptLoader = __filename;
 
+const cwd = process.cwd();
+
 const MINIAPP_CONFIG_FIELD = 'miniappConfig';
 
 // 1. JSON file will be written later because usingComponents may be modified
@@ -123,7 +125,7 @@ module.exports = function scriptLoader(content) {
             const componentPath = componentConfig.usingComponents[key];
             if (isNpmModule(componentPath)) {
               // component from node module
-              const realComponentPath = resolveModule.sync(componentPath, { paths: [this.resourcePath], preserveSymlinks: false });
+              const realComponentPath = resolveModule.sync(componentPath, { basedir: cwd, paths: [this.resourcePath], preserveSymlinks: false });
               const relativeComponentPath = normalizeNpmFileName(addRelativePathPrefix(relative(dirname(sourceNativeMiniappScriptFile), realComponentPath)));
               componentConfig.usingComponents[key] = normalizeOutputFilePath(removeExt(relativeComponentPath));
               // Native miniapp component js file will loaded by script-loader
@@ -270,8 +272,6 @@ module.exports = function scriptLoader(content) {
  */
 function normalizeNpmFileName(filename) {
   const repalcePathname = pathname => pathname.replace(/@/g, '_').replace(/node_modules/g, 'npm');
-
-  const cwd = process.cwd();
 
   if (!filename.includes(cwd)) return repalcePathname(filename);
 


### PR DESCRIPTION
- [x] jsx2mp: 添加 basedir 配置，以应对构建器与项目目录不一致的情况