### PR TITLE
Release/jsx2mp 0706

### DIFF
--- a/packages/jsx2mp-runtime/CHANGELOG.md
+++ b/packages/jsx2mp-runtime/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.4.22] - 2021-07-6
+
+### Fixed
+
+- Can't share successfully when user doesn't config app.onShareAppMessage
+
+### Added
+
+- Support pass variables in runApp to app instance
+
 ## [0.4.21] - 2021-03-30
 
 ### Added

--- a/packages/jsx2mp-runtime/package.json
+++ b/packages/jsx2mp-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx2mp-runtime",
-  "version": "0.4.21",
+  "version": "0.4.22",
   "description": "Runtime for jsx2mp.",
   "miniprogram": ".",
   "files": [

--- a/packages/jsx2mp-runtime/src/bridge.js
+++ b/packages/jsx2mp-runtime/src/bridge.js
@@ -347,15 +347,18 @@ export function runApp(...args) {
     },
     onError(error) {
       executeCallback(this, ON_ERROR, error);
-    },
-    onShareAppMessage(shareOptions) {
+    }
+  };
+
+  if (appCycles[ON_SHARE_APP_MESSAGE]) {
+    appOptions.onShareAppMessage = function(shareOptions) {
       // There will be one callback fn for shareAppMessage at most
       const callbackQueue = appCycles[ON_SHARE_APP_MESSAGE];
       if (Array.isArray(callbackQueue) && callbackQueue[0]) {
         return callbackQueue[0].call(this, shareOptions);
       }
-    }
-  };
+    };
+  }
 
   if (isQuickApp) {
     // Quickapp's app returns config as JSON

--- a/packages/jsx2mp-runtime/src/bridge.js
+++ b/packages/jsx2mp-runtime/src/bridge.js
@@ -313,6 +313,7 @@ export function runApp(...args) {
   if (staticConfig) {
     throw new Error('runApp can only be called once.');
   }
+  let appProps = {};
   if (args.length === 1) {
     // runApp(staticConfig)
     staticConfig = args[0];
@@ -325,6 +326,7 @@ export function runApp(...args) {
     setModernMode(true);
     staticConfig = args[1];
     if (args[0].app) {
+      appProps = args[0].app;
       [ON_LAUNCH, ON_ERROR, ON_HIDE, ON_SHOW, ON_SHARE_APP_MESSAGE].forEach(cycle => {
         if (typeof args[0].app[cycle] === 'function') {
           useAppEffect(cycle, args[0].app[cycle]);
@@ -335,6 +337,7 @@ export function runApp(...args) {
   __updateRouterMap(staticConfig);
 
   const appOptions = {
+    ...appProps,
     // Bridge app launch.
     onLaunch(launchOptions) {
       executeCallback(this, ON_LAUNCH, launchOptions);


### PR DESCRIPTION
- [x] feat: 支持将用户在 runApp 中传入的普通属性透传至小程序 app 实例上 https://github.com/raxjs/miniapp/pull/166

- [x] fix: 修复用户未配置 onShareAppMessage 时分享报错的问题  https://github.com/raxjs/miniapp/pull/172