### PR TITLE
feat(miniapp): remove copy-webpack-plugin dependency

### DIFF
--- a/packages/miniapp-runtime-config/CHANGELOG.md
+++ b/packages/miniapp-runtime-config/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.7] - 2021-07-12
+
+### Changed
+
+- Remove copy-webpack-plugin dependency and inherit the config from build-plugin-rax-miniapp
 ## [0.3.6] - 2021-04-27
 
 ### Changed

--- a/packages/miniapp-runtime-config/CHANGELOG.md
+++ b/packages/miniapp-runtime-config/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Remove copy-webpack-plugin dependency and inherit the config from build-plugin-rax-miniapp
+
 ## [0.3.6] - 2021-04-27
 
 ### Changed

--- a/packages/miniapp-runtime-config/package.json
+++ b/packages/miniapp-runtime-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miniapp-runtime-config",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "miniapp runtime project config",
   "author": "Rax Team",
   "homepage": "https://github.com/raxjs/miniapp#readme",
@@ -24,7 +24,6 @@
     "webpack": "^4.0.0"
   },
   "dependencies": {
-    "copy-webpack-plugin": "^6.0.3",
     "miniapp-builder-shared": "^0.2.0",
     "rax-miniapp-babel-plugins": "^0.1.3",
     "rax-miniapp-config-webpack-plugin": "^2.0.0",

--- a/packages/miniapp-runtime-config/src/setConfig.js
+++ b/packages/miniapp-runtime-config/src/setConfig.js
@@ -129,11 +129,9 @@ module.exports = (
   ]);
 
   if (needCopyList.length > 0) {
-    config.plugin('copyWebpackPluginForRuntimeMiniapp').use(CopyWebpackPlugin, [
-      {
-        patterns: needCopyList,
-      },
-    ]);
+    config.plugin('CopyWebpackPlugin').tap(([copyList]) => {
+      return [copyList.concat(needCopyList)];
+    });
   }
 
   config.devServer.writeToDisk(true).noInfo(true).inline(false);


### PR DESCRIPTION
- [x]  Remove copy-webpack-plugin dependency and inherit the config from build-plugin-rax-miniapp. Because copy-webpack-plugin v6 will make cache of alibaba miniapp IDE expired.