### PR TITLE
Release/miniapp 0713

### DIFF
--- a/packages/miniapp-builder-shared/CHANGELOG.md
+++ b/packages/miniapp-builder-shared/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.2.7] - 2021-06-10
+
+### Fixed
+
+- windows tabBar item `pagePath`
+
 ## [0.2.6] - 2021-06-01
 
 ### Changed

--- a/packages/miniapp-builder-shared/package.json
+++ b/packages/miniapp-builder-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miniapp-builder-shared",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "miniapp project builder shared lib",
   "author": "Rax Team",
   "homepage": "https://github.com/raxjs/miniapp#readme",

--- a/packages/miniapp-builder-shared/src/getAppConfig.js
+++ b/packages/miniapp-builder-shared/src/getAppConfig.js
@@ -31,10 +31,12 @@ module.exports = (rootDir, target, nativeLifeCycleMap, subAppRoot = '') => {
   }
 
   appConfig.routes.map(route => {
-    route.source = join(subAppRoot, route.source);
+    if (subAppRoot) {
+      route.source = `${subAppRoot}/${route.source}`;
+      route.subAppRoot = subAppRoot;
+    }
     route.name = route.source;
     route.entryName = getRouteName(route, rootDir);
-    if (subAppRoot) route.subAppRoot = subAppRoot;
 
     if (!Array.isArray(route.targets)) {
       addPage(route);

--- a/packages/miniapp-render/CHANGELOG.md
+++ b/packages/miniapp-render/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.7.0] - 2021-07-13
+
+### Changed
+
+- Move js bundle execution time to app onLaunch licecycle in wechat
+- Support return result in trigger function of event-target
+
 ## [2.6.1] - 2021-06-09
 
 ### Fixed

--- a/packages/miniapp-render/package.json
+++ b/packages/miniapp-render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miniapp-render",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "description": "DOM simulator for MiniApp",
   "files": [
     "dist"

--- a/packages/miniapp-render/src/constants.js
+++ b/packages/miniapp-render/src/constants.js
@@ -24,6 +24,8 @@ export const BUILTIN_COMPONENT_LIST = new Set([
 
 export const BODY_NODE_ID = 'e-body';
 
+export const INDEX_PAGE = 'index-page';
+
 export const STATIC_COMPONENTS = new Set(['view', 'text', 'image']); // With no events components
 
 export const PURE_COMPONENTS = new Set(['view', 'h-element']); // With no events or props && equal to TOUCH_COMPONENTS

--- a/packages/miniapp-render/src/createConfig/app.js
+++ b/packages/miniapp-render/src/createConfig/app.js
@@ -3,6 +3,8 @@ import { isMiniApp } from 'universal-env';
 import createWindow from '../window';
 import createDocument from '../document';
 import cache from '../utils/cache';
+import { INDEX_PAGE } from '../constants';
+
 
 export default function(init, config, packageName = '', nativeAppConfig = {}) {
   cache.setConfig({
@@ -11,53 +13,38 @@ export default function(init, config, packageName = '', nativeAppConfig = {}) {
   });
   const { onLaunch, onShow, onHide, onError, onPageNotFound, ...rest } = nativeAppConfig;
   const appConfig = {
-    launched: isMiniApp,
     onLaunch(options) {
       onLaunch && onLaunch.call(this, options);
 
       const window = createWindow();
       cache.setWindow(packageName, window);
+      // `getCurrentPages()` can get the first page in app onLaunch in the following situation:
+      // 1. In alibaba miniapp
+      // 2. The first page is not from plugin
+      // eslint-disable-next-line no-undef
+      const currentPageId = getCurrentPages()[0] ? `${getCurrentPages()[0].route}-1` : INDEX_PAGE;
+      const currentDocument = createDocument(currentPageId);
+      this.__pageId = window.__pageId = currentPageId;
 
-      // In wechat miniprogram getCurrentPages() length is 0, so web bundle only can be executed in first page
-      if (isMiniApp) {
-        // Use page route as pageId key word
-        // eslint-disable-next-line no-undef
-        const currentPageId = `${getCurrentPages()[0].route}-1`;
-        const currentDocument = createDocument(currentPageId);
-        this.__pageId = window.__pageId = currentPageId;
+      init(window, currentDocument, this);
+      window._trigger('launch', {
+        event: {
+          options,
+          context: this
+        }
+      });
 
-        init(window, currentDocument);
-        window._trigger('launch', {
-          event: {
-            options,
-            context: this
-          }
-        });
-      } else {
-        this.init = (document) => {
-          init(window, document);
-          window._trigger('launch', {
-            event: {
-              options,
-              context: this
-            }
-          });
-        };
-      }
       this.window = window;
     },
     onShow(options) {
       onShow && onShow.call(this, options);
 
-      this.__showOptions = options;
-      if (this.window && this.launched) {
-        this.window._trigger('appshow', {
-          event: {
-            options,
-            context: this
-          }
-        });
-      }
+      this.window && this.window._trigger('appshow', {
+        event: {
+          options,
+          context: this
+        }
+      });
     },
     onHide() {
       onHide && onHide.call(this);

--- a/packages/miniapp-render/src/document.js
+++ b/packages/miniapp-render/src/document.js
@@ -73,6 +73,12 @@ class Document extends EventTarget {
     }
   }
 
+  _switchPageId(pageId) {
+    this.__pageId = pageId;
+    const rootNodeId = `${BODY_NODE_ID}-${pageId}`;
+    cache.setNode(rootNodeId, this.__root);
+  }
+
   // Node type
   get nodeType() {
     return Node.DOCUMENT_NODE;
@@ -220,9 +226,7 @@ class Document extends EventTarget {
 export default function createDocument(pageId) {
   const document = new Document(pageId);
 
-  cache.init(pageId, {
-    document
-  });
+  cache.init(pageId, document);
 
   return document;
 };

--- a/packages/miniapp-render/src/event/event-target.js
+++ b/packages/miniapp-render/src/event/event-target.js
@@ -239,16 +239,19 @@ class EventTarget {
     }
 
     if (handlers && handlers.length) {
+      let result;
       // Trigger addEventListener binded events
       handlers.forEach(handler => {
         if (event && event._immediateStop) return;
         try {
           const processedArgs = event ? [event, ...args] : [...args];
-          handler.call(this || null, ...processedArgs);
+          result = handler.call(this || null, ...processedArgs); // Only the last result will be returned
         } catch (err) {
           console.error(err);
         }
       });
+
+      return result;
     }
   }
 

--- a/packages/miniapp-render/src/node/attribute.js
+++ b/packages/miniapp-render/src/node/attribute.js
@@ -1,3 +1,5 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { isBaiduSmartProgram } from 'universal-env';
 import { toCamel } from '../utils/tool';
 
 class Attribute {
@@ -22,7 +24,9 @@ class Attribute {
       }
       if (element._isRendered()) {
         const payload = {
-          path: `${element._path}.${name}`,
+          // In baidu smartprogram, setData path supports like: root.children.0['scroll-into-view']
+          // While in wechat miniprogram, the same setData path muse be: root.children.[0].scroll-into-view
+          path: isBaiduSmartProgram ? `${element._path}['${name}']` : `${element._path}.${name}`,
           value: value
         };
         element._triggerUpdate(payload, immediate);
@@ -76,7 +80,7 @@ class Attribute {
         delete element.dataset[datasetName];
       }
       const payload = {
-        path: `${element._path}.${name}`,
+        path: isBaiduSmartProgram ? `${element._path}['${name}']` : `${element._path}.${name}`,
         value: ''
       };
       element._triggerUpdate(payload);

--- a/packages/miniapp-render/src/node/element/custom-component.js
+++ b/packages/miniapp-render/src/node/element/custom-component.js
@@ -37,7 +37,7 @@ class CustomComponent extends Element {
         const eventName = `${this.__tagName}_${event}_${getId()}`;
         renderInfo[event] = eventName;
         cache.setCustomComponentMethods(eventName, (...args) => {
-          this._trigger(event, { args });
+          return this._trigger(event, { args });
         });
       });
     }

--- a/packages/miniapp-render/src/utils/cache.js
+++ b/packages/miniapp-render/src/utils/cache.js
@@ -12,8 +12,8 @@ const pagesCache = [];
 const elementMethodsCache = new Map();
 
 // Init
-function init(pageId, options) {
-  pageMap[pageId] = options.document;
+function init(pageId, document) {
+  pageMap[pageId] = document;
 }
 
 // Destroy

--- a/packages/rax-miniapp-runtime-webpack-plugin/CHANGELOG.md
+++ b/packages/rax-miniapp-runtime-webpack-plugin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [4.7.0] - 2021-07-13
+
+### Changed
+
+- Pass app instance to js bundle in cases that getApp() can't get app instance
+
 ## [4.6.1] - 2021-06-09
 
 ### Fixed

--- a/packages/rax-miniapp-runtime-webpack-plugin/package.json
+++ b/packages/rax-miniapp-runtime-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rax-miniapp-runtime-webpack-plugin",
-  "version": "4.6.1",
+  "version": "4.7.0",
   "description": "A webpack plugin for miniapp runtime build",
   "main": "src/index.js",
   "homepage": "https://github.com/raxjs/miniapp#readme",

--- a/packages/rax-miniapp-runtime-webpack-plugin/src/generators/app.js
+++ b/packages/rax-miniapp-runtime-webpack-plugin/src/generators/app.js
@@ -13,7 +13,7 @@ function generateAppJS(
   { target, command, withNativeAppConfig }
 ) {
   const init =
-`function init(window, document) {${commonAppJSFilePaths.map(filePath => `require('${getAssetPath(filePath, 'app.js')}')(window, document)`).join(';')}}`;
+`function init(window, document, app) {${commonAppJSFilePaths.map(filePath => `require('${getAssetPath(filePath, 'app.js')}')(window, document, app)`).join(';')}}`;
   const requireNativeAppConfig = withNativeAppConfig ? "const nativeAppConfig = require('./miniapp-native/app');" : 'const nativeAppConfig = {}';
   const appJsContent = `${requireNativeAppConfig}
 const render = require('./render');

--- a/packages/rax-miniapp-runtime-webpack-plugin/src/utils/wrapChunks.js
+++ b/packages/rax-miniapp-runtime-webpack-plugin/src/utils/wrapChunks.js
@@ -20,9 +20,9 @@ module.exports = function(compilation, chunks, target) {
         // Page js
         const headerContent =
 `${FunctionPolyfill}
-module.exports = function(window, document) {
+module.exports = function(window, document, app) {
   const HTMLElement = window["HTMLElement"];
-  const documentModifyCallbacks = getApp().__documentModifyCallbacks;
+  const documentModifyCallbacks = (getApp() || app).__documentModifyCallbacks;
   if (Array.isArray(documentModifyCallbacks)) {
     documentModifyCallbacks.push((val) => {
       document = val;


### PR DESCRIPTION
- [x] 将微信端的 JS bundle 执行时机调整为 app onLaunch，与支付宝小程序保持一致 https://github.com/raxjs/miniapp/pull/162
- [x] trigger 函数支持 return 结果 https://github.com/raxjs/miniapp/pull/170
- [x] 修复 windows 路径 pagePath 编译问题 https://github.com/raxjs/miniapp/pull/160 