### PR TITLE
fix(miniapp): can't get correct event target

### DIFF
--- a/packages/miniapp-render/src/bridge/createEventProxy.js
+++ b/packages/miniapp-render/src/bridge/createEventProxy.js
@@ -36,11 +36,7 @@ export default function() {
       const domNode = this.getDomNodeFromEvt(evt);
       const document = domNode.ownerDocument;
       if (document && document.__checkEvent(evt)) {
-        if (isMiniApp) {
-          this.callEvent(eventName, evt, extra, evt.target.targetDataset.privateNodeId);
-        } else {
-          this.callEvent(eventName, evt, extra, evt.target.dataset.privateNodeId);
-        }
+        this.callEvent(eventName, evt, extra, evt.currentTarget.dataset.privateNodeId);
       }
     };
   });

--- a/packages/miniapp-render/src/event/event-target.js
+++ b/packages/miniapp-render/src/event/event-target.js
@@ -122,7 +122,7 @@ class EventTarget {
       // Special handling here, not directly return the applet's event object
       event = new Event({
         name: eventName,
-        target,
+        target: miniprogramEvent.target || target, // Use native event target first
         detail: miniprogramEvent.detail || { ...miniprogramEvent }, // Some info doesn't exist in event.detail but in event directly, like Alibaba MiniApp
         timeStamp: miniprogramEvent.timeStamp,
         touches: miniprogramEvent.touches,

--- a/packages/miniapp-runtime-config/src/setConfig.js
+++ b/packages/miniapp-runtime-config/src/setConfig.js
@@ -7,7 +7,6 @@ const {
 const getMiniAppBabelPlugins = require('rax-miniapp-babel-plugins');
 const MiniAppRuntimePlugin = require('rax-miniapp-runtime-webpack-plugin');
 const MiniAppConfigPlugin = require('rax-miniapp-config-webpack-plugin');
-const CopyWebpackPlugin = require('copy-webpack-plugin');
 const { resolve, dirname } = require('path');
 
 /**


### PR DESCRIPTION
Rax 小程序经过模板优化后，未绑定点击事件的组件，其模板上将不再绑定 onTap 事件，其导致用户在以下情况下，获取的 e.target 为根节点：

```jsx
export default function Home() {
  useEffect(() => {
    document.addEventListener('click', function(e) {
      debugger;
      console.log('e', e.target);
    }, true);
  }, []);
  return (
    <View>
      <Text id="test1">未绑定点击事件</Text>
      <Text id="test2" onClick={() => {console.log(123123)}}>已绑定点击事件</Text>
    </View>
  );
}
```

原因在于，用户点击 test2 节点时，该节点对应模板上绑定的 onTap 事件触发，其经过 rax 小程序内部的事件系统处理冒泡捕获等流程。而用户点击 test1 节点时，模板上未绑定 onTap，只有根节点对应模板的 onTap 事件触发，导致用户获取的 target 错误指向根节点。因此代码修改为生成 event 对象时，优先以小程序原生返回的 target 为准，并且回滚之前的从 event.target 获取 dataset 的操作。
