### PR TITLE
feat(miniapp): support native page lifecycle listen in plugin project

### DIFF
--- a/packages/miniapp-runtime-config/src/setBaseConfig.js
+++ b/packages/miniapp-runtime-config/src/setBaseConfig.js
@@ -60,6 +60,7 @@ module.exports = (
               rootDir,
               usingPlugins,
               runtimeDependencies: userConfig.runtimeDependencies,
+              isPluginProject
             }),
           },
         ];

--- a/packages/rax-miniapp-babel-plugins/src/index.js
+++ b/packages/rax-miniapp-babel-plugins/src/index.js
@@ -1,4 +1,4 @@
-module.exports = function({ usingComponents, nativeLifeCycleMap, target, rootDir, usingPlugins, runtimeDependencies }) {
+module.exports = function({ usingComponents, nativeLifeCycleMap, target, rootDir, usingPlugins, runtimeDependencies, isPluginProject }) {
   return [
     require.resolve('./plugins/babel-plugin-remove-Function'),
     require.resolve('./plugins/babel-plugin-external-module'),
@@ -6,6 +6,7 @@ module.exports = function({ usingComponents, nativeLifeCycleMap, target, rootDir
       require.resolve('./plugins/babel-plugin-native-lifecycle'),
       {
         nativeLifeCycleMap,
+        isPluginProject
       },
     ],
     [

--- a/packages/rax-miniapp-babel-plugins/src/plugins/babel-plugin-native-lifecycle.js
+++ b/packages/rax-miniapp-babel-plugins/src/plugins/babel-plugin-native-lifecycle.js
@@ -1,7 +1,7 @@
 const CodeError = require('../utils/CodeError');
 const getPagePath = require('../utils/getPagePath');
 
-module.exports = function visitor({ types: t }, { nativeLifeCycleMap }) {
+module.exports = function visitor({ types: t }, { nativeLifeCycleMap, isPluginProject }) {
   return {
     visitor: {
       CallExpression(path, { filename, file: { code } }) {
@@ -15,11 +15,34 @@ module.exports = function visitor({ types: t }, { nativeLifeCycleMap }) {
               path.node.arguments[1].elements.forEach(element => {
                 nativeLifeCycle[element.value] = true;
               });
+              path.remove();
+              return;
             } else {
               throw new CodeError(code, path.node.loc,
                 "registerNativeEventListeners's second argument should be an array, like ['onReachBottom']");
             }
           }
+          /* In miniapp plugins project,
+            transform addNativeEventListener -> document.addEventListener
+            transform removeNativeEventListener -> document.removeEventListener
+          */
+          if (isPluginProject) {
+            if (t.isIdentifier(path.node.callee, {
+              name: 'addNativeEventListener'
+            })) {
+              path.get('callee').replaceWith(t.memberExpression(t.identifier('document'), t.identifier('addEventListener')))
+            } else if (t.isIdentifier(path.node.callee, {
+              name: 'removeNativeEventListener'
+            })) {
+              path.get('callee').replaceWith(t.memberExpression(t.identifier('document'), t.identifier('removeEventListener')))
+            }
+          }
+        }
+      },
+      ImportDeclaration(path) {
+        // In miniapp plugin project, remove rax-app because it can't be used directly
+        if (isPluginProject && t.isStringLiteral(path.node.source, { value: 'rax-app' })) {
+          path.remove();
         }
       }
     }

--- a/packages/rax-miniapp-babel-plugins/src/plugins/babel-plugin-native-lifecycle.js
+++ b/packages/rax-miniapp-babel-plugins/src/plugins/babel-plugin-native-lifecycle.js
@@ -30,11 +30,11 @@ module.exports = function visitor({ types: t }, { nativeLifeCycleMap, isPluginPr
             if (t.isIdentifier(path.node.callee, {
               name: 'addNativeEventListener'
             })) {
-              path.get('callee').replaceWith(t.memberExpression(t.identifier('document'), t.identifier('addEventListener')))
+              path.get('callee').replaceWith(t.memberExpression(t.identifier('document'), t.identifier('addEventListener')));
             } else if (t.isIdentifier(path.node.callee, {
               name: 'removeNativeEventListener'
             })) {
-              path.get('callee').replaceWith(t.memberExpression(t.identifier('document'), t.identifier('removeEventListener')))
+              path.get('callee').replaceWith(t.memberExpression(t.identifier('document'), t.identifier('removeEventListener')));
             }
           }
         }


### PR DESCRIPTION
在小程序插件项目中，无法使用 rax-app，因此页面的事件监听也无法处理。本 pr 使用 babel 插件在插件项目中做了以下处理以兼容监听页面事件的代码：

1. 删除 `import { registerNativeEventListeners, addNativeEventListener, removeNativeEventListener } from 'rax-app';`
2. 将 `addNativeEventListener ` 替换为 `document.addEventListener`
3. 将 `removeNativeEventListener` 替换为 `document.removeEventListener`
4. 收集完事件后删除 `registerNativeEventListeners(Index, ['onReachBottom']);`


方案B：

提供一个新的包，导出以下三个方法：

```js
export function registerNativeEventListeners(Klass, events) {
  // For rax miniapp runtime babel plugins prev compile
}

export function addNativeEventListener(eventName, callback) {
  document.addEventListener(eventName, callback);
}

export function removeNativeEventListener(evetName, callback) {
  document.removeEventListener(evetName, callback);
}
```