### PR TITLE
fix(miniapp): can't return correct event target

### DIFF
--- a/packages/miniapp-render/__tests__/event/event.test.js
+++ b/packages/miniapp-render/__tests__/event/event.test.js
@@ -18,7 +18,7 @@ test('event', () => {
   const d = document.querySelector('footer');
   const e = document.querySelector('#bb4');
 
-  const miniprogramEvent = {timeStamp: Date.now};
+  const miniprogramEvent = { timeStamp: Date.now, target: { dataset: {}}};
   const seqList = [];
 
   // addEventListener/removeEventListener

--- a/packages/miniapp-render/src/event/event-target.js
+++ b/packages/miniapp-render/src/event/event-target.js
@@ -1,6 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { isWeChatMiniProgram, isMiniApp } from 'universal-env';
+import { isMiniApp } from 'universal-env';
 import Event from './event';
+import cache from '../utils/cache';
 import CustomEvent from './custom-event';
 
 /**
@@ -120,9 +121,12 @@ class EventTarget {
 
     if (!event) {
       // Special handling here, not directly return the applet's event object
+      const targetNodeId = isMiniApp ? miniprogramEvent.target.targetDataset.privateNodeId : miniprogramEvent.target.dataset.privateNodeId;
+      // If different and native event target contains dataset, use native event target first
+      const realTarget = (targetNodeId && (targetNodeId !== target.__nodeId)) ? cache.getNode(targetNodeId) : target;
       event = new Event({
         name: eventName,
-        target: miniprogramEvent.target || target, // Use native event target first
+        target: realTarget,
         detail: miniprogramEvent.detail || { ...miniprogramEvent }, // Some info doesn't exist in event.detail but in event directly, like Alibaba MiniApp
         timeStamp: miniprogramEvent.timeStamp,
         touches: miniprogramEvent.touches,

--- a/packages/miniapp-render/src/event/event-target.js
+++ b/packages/miniapp-render/src/event/event-target.js
@@ -123,7 +123,7 @@ class EventTarget {
       // Special handling here, not directly return the applet's event object
       const targetNodeId = isMiniApp ? miniprogramEvent.target.targetDataset.privateNodeId : miniprogramEvent.target.dataset.privateNodeId;
       // If different and native event target contains dataset, use native event target first
-      const realTarget = (targetNodeId && (targetNodeId !== target.__nodeId)) ? cache.getNode(targetNodeId) : target;
+      const realTarget = targetNodeId && targetNodeId !== target.__nodeId ? cache.getNode(targetNodeId) : target;
       event = new Event({
         name: eventName,
         target: realTarget,


### PR DESCRIPTION
- [x] 存在用户从 target 中取值（例如 input 事件取 event.target.value 等情况），因此这里应该返回 JS 内存中模拟的 target 对象，而不是小程序容器层返回的 target。当小程序容器层返回的 target 中存在 nodeId 数据时，去对应内存中找到模拟的 target 对象，否则仍以当前传入的 target 节点为准。