### PR TITLE
feat(miniapp): support install npm in subpackages

### DIFF
--- a/packages/miniapp-builder-shared/src/autoInstallNpm.js
+++ b/packages/miniapp-builder-shared/src/autoInstallNpm.js
@@ -1,35 +1,41 @@
 const execa = require('execa');
+const { join } = require('path');
 const { checkAliInternal } = require('ice-npm-utils');
 
 let isAliInternal;
 let npmRegistry;
 
-async function autoInstallNpm(dir, callback) {
+function executeInstall(cwd) {
+  return execa('npm', ['install', '--production', `--registry=${npmRegistry}`], { cwd })
+}
+
+function warnInstallManually() {
+  console.log(
+    `\nInstall dependencies failed, please enter dist path and retry installing by yourself\n`
+  );
+}
+
+async function autoInstallNpm(callback, { distDir, packageJsonFilePath = []}) {
   if (isAliInternal === undefined) {
     isAliInternal = await checkAliInternal();
     npmRegistry = isAliInternal
       ? 'https://registry.npm.alibaba-inc.com'
       : 'https://registry.npm.taobao.org';
   }
-  execa('npm', ['install', '--production', `--registry=${npmRegistry}`], {
-    cwd: dir,
-  })
-    .then(({ exitCode }) => {
-      if (!exitCode) {
-        callback();
-      } else {
-        console.log(
-          `\nInstall dependencies failed, please enter ${dir} and retry by yourself\n`
-        );
-        callback();
+  const installPromiseArray = packageJsonFilePath.map(installPath => {
+    return executeInstall(join(distDir, installPath))
+  });
+  Promise.all(installPromiseArray)
+    .then((results) => {
+      if (results.some(result => result.exitCode)) {
+        warnInstallManually();
       }
+      callback();
     })
     .catch(() => {
-      console.log(
-        `\nInstall dependencies failed, please enter ${dir} and retry by yourself\n`
-      );
+      warnInstallManually();
       callback();
-    });
+  })
 }
 
 module.exports = autoInstallNpm;

--- a/packages/miniapp-builder-shared/src/autoInstallNpm.js
+++ b/packages/miniapp-builder-shared/src/autoInstallNpm.js
@@ -6,13 +6,11 @@ let isAliInternal;
 let npmRegistry;
 
 function executeInstall(cwd) {
-  return execa('npm', ['install', '--production', `--registry=${npmRegistry}`], { cwd })
+  return execa('npm', ['install', '--production', `--registry=${npmRegistry}`], { cwd });
 }
 
 function warnInstallManually() {
-  console.log(
-    `\nInstall dependencies failed, please enter dist path and retry installing by yourself\n`
-  );
+  console.log('\nInstall dependencies failed, please enter dist path and retry installing by yourself\n');
 }
 
 async function autoInstallNpm(callback, { distDir, packageJsonFilePath = []}) {
@@ -23,7 +21,7 @@ async function autoInstallNpm(callback, { distDir, packageJsonFilePath = []}) {
       : 'https://registry.npm.taobao.org';
   }
   const installPromiseArray = packageJsonFilePath.map(installPath => {
-    return executeInstall(join(distDir, installPath))
+    return executeInstall(join(distDir, installPath));
   });
   Promise.all(installPromiseArray)
     .then((results) => {
@@ -35,7 +33,7 @@ async function autoInstallNpm(callback, { distDir, packageJsonFilePath = []}) {
     .catch(() => {
       warnInstallManually();
       callback();
-  })
+    });
 }
 
 module.exports = autoInstallNpm;

--- a/packages/miniapp-compile-config/src/plugins/AutoInstallNpm.js
+++ b/packages/miniapp-compile-config/src/plugins/AutoInstallNpm.js
@@ -23,7 +23,7 @@ module.exports = class AutoInstallNpmPlugin {
         this.subPackages.forEach(({ dependencies = {}, source = '' }) => {
           writeJSONSync(join(distDir, dirname(source), 'package.json'), { dependencies });
           packageJsonFilePath.push(dirname(source));
-        })
+        });
       }
 
       if (!this.autoInstall) {

--- a/packages/miniapp-compile-config/src/plugins/AutoInstallNpm.js
+++ b/packages/miniapp-compile-config/src/plugins/AutoInstallNpm.js
@@ -1,6 +1,6 @@
 const { autoInstallNpm } = require('miniapp-builder-shared');
 const { writeJSONSync } = require('fs-extra');
-const { join } = require('path');
+const { join, dirname } = require('path');
 /**
  * Auto install npm
  */
@@ -8,21 +8,28 @@ module.exports = class AutoInstallNpmPlugin {
   constructor({ nativePackage = {} }) {
     this.autoInstall = nativePackage.autoInstall;
     this.dependencies = nativePackage.dependencies || null;
+    this.subPackages = nativePackage.subPackages || null;
   }
   apply(compiler) {
     compiler.hooks.done.tapAsync('AutoInstallNpmPlugin', async(stats, callback) => {
+      const packageJsonFilePath = [];
       const distDir = stats.compilation.outputOptions.path;
       // Generate package.json
       if (this.dependencies) {
-        const pkgFilePath = join(distDir, 'package.json');
-        writeJSONSync(pkgFilePath, {
-          dependencies: this.dependencies
-        });
+        writeJSONSync(join(distDir, 'package.json'), { dependencies: this.dependencies });
+        packageJsonFilePath.push('');
       }
+      if (this.subPackages) {
+        this.subPackages.forEach(({ dependencies = {}, source = '' }) => {
+          writeJSONSync(join(distDir, dirname(source), 'package.json'), { dependencies });
+          packageJsonFilePath.push(dirname(source));
+        })
+      }
+
       if (!this.autoInstall) {
         return callback();
       }
-      await autoInstallNpm(distDir, callback);
+      await autoInstallNpm(callback, { distDir, packageJsonFilePath });
     });
   }
 };

--- a/packages/rax-miniapp-runtime-webpack-plugin/src/generators/pkg.js
+++ b/packages/rax-miniapp-runtime-webpack-plugin/src/generators/pkg.js
@@ -1,14 +1,14 @@
-const { resolve } = require('path');
+const { resolve, dirname, join } = require('path');
 const { readJSONSync } = require('fs-extra');
 const addFileToCompilation = require('../utils/addFileToCompilation');
 
-module.exports = function(compilation, { target, command, declaredDep }) {
+module.exports = function(compilation, { target, command, declaredDep, source = '' }) {
   const pkgPath = resolve(process.cwd(), 'package.json');
   const dependencies = declaredDep || readJSONSync(pkgPath, {
     encoding: 'utf-8'
   }).dependencies;
   addFileToCompilation(compilation, {
-    filename: 'package.json',
+    filename: join(dirname(source), 'package.json'),
     content: JSON.stringify({
       dependencies
     }),

--- a/packages/rax-miniapp-runtime-webpack-plugin/src/index.js
+++ b/packages/rax-miniapp-runtime-webpack-plugin/src/index.js
@@ -1,4 +1,4 @@
-const { resolve, join } = require('path');
+const { resolve, join, dirname } = require('path');
 const { readJsonSync, existsSync } = require('fs-extra');
 const isEqual = require('lodash.isequal');
 const { constants: { MINIAPP } } = require('miniapp-builder-shared');
@@ -59,6 +59,7 @@ class MiniAppRuntimePlugin {
     let lastUsingComponents = {};
     let lastUsingPlugins = {};
     let needAutoInstallDependency = false;
+    const packageJsonFilePath = [];
 
     // Execute when compilation created
     compiler.hooks.compilation.tap(PluginName, (compilation) => {
@@ -156,6 +157,20 @@ class MiniAppRuntimePlugin {
             target,
             command,
             declaredDep: nativePackage.dependencies
+          });
+          packageJsonFilePath.push('');
+          needAutoInstallDependency = true;
+        }
+        debugger;
+        if (nativePackage.subPackages) {
+          nativePackage.subPackages.forEach(({ dependencies = {}, source = '' }) => {
+            generatePkg(compilation, {
+              target,
+              command,
+              declaredDep: dependencies,
+              source
+            });
+            packageJsonFilePath.push(dirname(source));
           });
           needAutoInstallDependency = true;
         }
@@ -327,7 +342,7 @@ class MiniAppRuntimePlugin {
         return callback();
       }
       const distDir = stats.compilation.outputOptions.path;
-      await autoInstallNpm(distDir, callback);
+      await autoInstallNpm(callback, { distDir, packageJsonFilePath });
     });
   }
 }

--- a/packages/rax-miniapp-runtime-webpack-plugin/src/index.js
+++ b/packages/rax-miniapp-runtime-webpack-plugin/src/index.js
@@ -161,7 +161,6 @@ class MiniAppRuntimePlugin {
           packageJsonFilePath.push('');
           needAutoInstallDependency = true;
         }
-        debugger;
         if (nativePackage.subPackages) {
           nativePackage.subPackages.forEach(({ dependencies = {}, source = '' }) => {
             generatePkg(compilation, {


### PR DESCRIPTION
微信小程序支持在分包目录下安装 npm 包以减轻主包体积压力。Rax 小程序需要用户在 `build.json` 的 `nativePackage` 中增加以下配置，以支持上述能力：

```json
{
  "targets": [
    "wechat-miniprogram"
  ],
  "wechat-miniprogram": {
    "subPackages": true,
    "nativePackage": {
      "autoInstall": false,
      // 主包安装依赖
      "dependencies": {
        "jquery": "*",
        "axios": "*"
      },
      // 其他子包安装依赖
      "subPackages": [
        {
          // source 对应子包入口 app 代码
          "source": "pages/About/app",
          "dependencies": {
            "jquery": "*"
          }
        },
        {
          "source": "pages/Profile/app",
          "dependencies": {
            "lodash": "*"
          }
        }
      ]
    }
  },
}
```