### PR TITLE
fix: return renamed index in list

### DIFF
--- a/packages/jsx-compiler/CHANGELOG.md
+++ b/packages/jsx-compiler/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [0.4.35] - 2021-08-27
 
-- Return renamed index props in list
+- Return renamed index in list
 
 ## [0.4.34] - 2021-08-24
 

--- a/packages/jsx-compiler/CHANGELOG.md
+++ b/packages/jsx-compiler/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.4.35] - 2021-08-27
+
+- Return renamed index props in list
+
 ## [0.4.34] - 2021-08-24
 
 - Compatible with old version of jsx2mp-runtime, which not support list key

--- a/packages/jsx-compiler/package.json
+++ b/packages/jsx-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx-compiler",
-  "version": "0.4.34",
+  "version": "0.4.35-0",
   "license": "BSD-3-Clause",
   "description": "Parser for Rax JSX Statements.",
   "files": [

--- a/packages/jsx-compiler/package.json
+++ b/packages/jsx-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx-compiler",
-  "version": "0.4.35-0",
+  "version": "0.4.35",
   "license": "BSD-3-Clause",
   "description": "Parser for Rax JSX Statements.",
   "files": [

--- a/packages/jsx-compiler/src/modules/__tests__/jsx-plus.js
+++ b/packages/jsx-compiler/src/modules/__tests__/jsx-plus.js
@@ -31,6 +31,7 @@ describe('Directives', () => {
         <View a:for={array.map((val, ${index}) => {
     return {
       val: val,
+      ${index}: ${index},
       _key: ${key}
     };
   })} a:key="_key" a:for-item="val" a:for-index="${index}">{{
@@ -62,9 +63,11 @@ describe('Directives', () => {
       item: item.map((item2, ${index2}) => {
         return {
           item2: item2,
+          ${index2}: ${index2},
           _key: ${key2}
         };
       }),
+      ${index1}: ${index1},
       _key: ${key1}
     };
   })} a:key="_key" a:for-item="item" a:for-index="${index1}">
@@ -104,17 +107,18 @@ describe('Directives', () => {
       row: row.map((col, ${index2}) => {
         return {
           col: col,
-          _key: ${key2},
-          _d0: ${index2}
+          ${index2}: ${index2},
+          _key: ${key2}
         };
       }),
+      ${index1}: ${index1},
       _key: ${key1},
       _d0: 'test_' + ${index1}
     };
   })} a:key="_key" a:for-item="row" a:for-index="${index1}">
           <View a:for={row} a:key="_key" a:for-item="col" a:for-index="${index2}">
-            <Text key="{{col._d0}}">{{
-          col._d0
+            <Text key="{{col.${index2}}}">{{
+          col.${index2}
         }}</Text>
           </View>
         </View>
@@ -138,6 +142,7 @@ describe('Directives', () => {
         <View a:for={array.map((val, ${index}) => {
     return {
       val: val,
+      ${index}: ${index},
       _key: ${key},
       _d0: format(val)
     };
@@ -164,6 +169,7 @@ describe('Directives', () => {
         <View a:for={array.map((val, ${index}) => {
     return {
       val: val,
+      ${index}: ${index},
       _key: ${key},
       _d0: format(val)
     };
@@ -190,6 +196,7 @@ describe('Directives', () => {
         <View a:for={list.map((item, ${index}) => {
     return {
       item: item,
+      ${index}: ${index},
       _key: ${key},
       _d0: item.id,
       _d1: format(item.val)
@@ -277,6 +284,7 @@ describe('Directives', () => {
 
     return {
       item: item,
+      ${index}: ${index},
       _key: ${key},
       _d0: "${id}" + ${index}
     };
@@ -314,11 +322,13 @@ describe('Directives', () => {
 
           return {
             item: item,
+            ${index2}: ${index2},
             _key: ${key2},
             _d0: "${id}" + ${index2}
           };
         })
       },
+      ${index1}: ${index1},
       _key: ${key1}
     };
   })} a:key="_key" a:for-item="item" a:for-index="${index1}">

--- a/packages/jsx-compiler/src/modules/__tests__/list.js
+++ b/packages/jsx-compiler/src/modules/__tests__/list.js
@@ -19,10 +19,10 @@ describe('Transform list', () => {
     expect(genCode(ast).code).toEqual(`<View><block a:for={arr.map((val, ${index}) => {
     return {
       val: val,
-      _key: ${key},
-      _d0: ${index}
+      ${index}: ${index},
+      _key: ${key}
     };
-  })} a:for-item="val" a:for-index="${index}" a:key="_key"><item data-value="{{val.val}}" data-key="{{val._d0}}" /></block></View>`);
+  })} a:for-item="val" a:for-index="${index}" a:key="_key"><item data-value="{{val.val}}" data-key="{{val.${index}}}" /></block></View>`);
   });
 
   it('transform array.map in JSXContainer', () => {
@@ -40,10 +40,10 @@ describe('Transform list', () => {
     expect(genCode(ast).code).toEqual(`<View><block a:for={arr.map((val, ${index}) => {
     return {
       val: val,
-      _key: ${key},
-      _d0: ${index}
+      ${index}: ${index},
+      _key: ${key}
     };
-  })} a:for-item="val" a:for-index="${index}" a:key="_key"><item data-value="{{val.val}}" data-key="{{val._d0}}" /></block></View>`);
+  })} a:for-item="val" a:for-index="${index}" a:key="_key"><item data-value="{{val.val}}" data-key="{{val.${index}}}" /></block></View>`);
   });
 
   it('bind list variable', () => {
@@ -59,6 +59,7 @@ describe('Transform list', () => {
     expect(genCode(ast).code).toEqual(`<View><block a:for={arr.map((item, ${index}) => {
     return {
       item: item,
+      ${index}: ${index},
       _key: ${key},
       _d0: item.title,
       _d1: {
@@ -80,7 +81,7 @@ describe('Transform list', () => {
     }, code, adapter);
     const key = '_key' + count;
     const index = 'index' + count++;
-    expect(genCode(ast, { concise: true }).code).toEqual(`<View><block a:for={[1, 2, 3].map((val, ${index}) => { return { val: val, _key: ${key}, _d0: ${index} }; })} a:for-item="val" a:for-index="${index}" a:key="_key"><Text>{{ val._d0 }}</Text></block></View>`);
+    expect(genCode(ast, { concise: true }).code).toEqual(`<View><block a:for={[1, 2, 3].map((val, ${index}) => { return { val: val, ${index}: ${index}, _key: ${key} }; })} a:for-item="val" a:for-index="${index}" a:key="_key"><Text>{{ val.${index} }}</Text></block></View>`);
   });
 
   it('nested list', () => {
@@ -127,9 +128,11 @@ describe('Transform list', () => {
       l1: l1.map((l2, ${index2}) => {
         return {
           l2: l2,
+          ${index2}: ${index2},
           _key: ${key2}
         };
       }),
+      ${index1}: ${index1},
       _key: ${key1}
     };
   })} a:for-item="l1" a:for-index="${index1}" a:key="_key"><View>
@@ -184,10 +187,12 @@ describe('Transform list', () => {
   <block a:for={arr.map((l1, ${index1}) => {
     return {
       l1: l1,
+      ${index1}: ${index1},
       _key: ${key1},
       _d0: list[l1].map((l2, ${index2}) => {
         return {
           l2: l2,
+          ${index2}: ${index2},
           _key: ${key2}
         };
       })
@@ -247,10 +252,12 @@ describe('Transform list', () => {
         list: l1.list.map((l2, ${index2}) => {
           return {
             l2: l2,
+            ${index2}: ${index2},
             _key: ${key2}
           };
         })
       },
+      ${index1}: ${index1},
       _key: ${key1}
     };
   })} a:for-item="l1" a:for-index="${index1}" a:key="_key"><View>
@@ -307,10 +314,12 @@ describe('Transform list', () => {
     const a = l1 || [];
     return {
       l1: l1,
+      ${index1}: ${index1},
       _key: ${key1},
       a: a.map((l2, ${index2}) => {
         return {
           l2: l2,
+          ${index2}: ${index2},
           _key: ${key2}
         };
       })
@@ -335,7 +344,7 @@ describe('Transform list', () => {
     }, code, adapter);
     const key = '_key' + count;
     const index = 'index' + count++;
-    expect(genCode(ast, { concise: true }).code).toEqual(`<View><block a:for={[1, 2, 3].map((item, ${index}) => { return { item: item, _key: ${key} }; })} a:for-item="item" a:for-index="${index}" a:key="_key"><Text>test</Text></block></View>`);
+    expect(genCode(ast, { concise: true }).code).toEqual(`<View><block a:for={[1, 2, 3].map((item, ${index}) => { return { item: item, ${index}: ${index}, _key: ${key} }; })} a:for-item="item" a:for-index="${index}" a:key="_key"><Text>test</Text></block></View>`);
   });
 
   it('list style', () => {
@@ -357,6 +366,7 @@ describe('Transform list', () => {
     };
     return {
       item: item,
+      ${index}: ${index},
       _key: ${key},
       _s0: __create_style__(style)
     };
@@ -398,10 +408,12 @@ describe('Transform list', () => {
         };
         return {
           it: it,
+          ${index2}: ${index2},
           _key: ${key2},
           _s0: __create_style__(style)
         };
       }),
+      ${index1}: ${index1},
       _key: ${key1}
     };
   })} a:for-item="item" a:for-index="${index1}" a:key="_key"><View>
@@ -423,6 +435,7 @@ describe('Transform list', () => {
     expect(genCode(ast).code).toEqual(`<View><block a:for={[1, 2, 3].map((item, ${index}) => {
     return {
       item: item,
+      ${index}: ${index},
       _key: ${key}
     };
   })} a:for-item="item" a:for-index="${index}" a:key="_key"><Text>test</Text></block></View>`);
@@ -443,6 +456,7 @@ describe('Transform list', () => {
     const a = ${index} * 2 + 10;
     return {
       item: item,
+      ${index}: ${index},
       _key: ${key},
       _d0: a
     };
@@ -466,12 +480,12 @@ describe('Transform list', () => {
     expect(genCode(ast).code).toEqual(`<View><block a:for={arr.map((val, ${index}) => {
     return {
       val: val,
+      ${index}: ${index},
       _key: ${key},
-      _d0: ${index},
-      _d1: format(${index})
+      _d0: format(${index})
     };
-  })} a:for-item="val" a:for-index="${index}" a:key="_key"><View data-value="{{val.val}}" data-key="{{val._d0}}">{{
-        val._d1
+  })} a:for-item="val" a:for-index="${index}" a:key="_key"><View data-value="{{val.val}}" data-key="{{val.${index}}}">{{
+        val._d0
       }}</View></block></View>`);
   });
 });

--- a/packages/jsx-compiler/src/modules/jsx-plus.js
+++ b/packages/jsx-compiler/src/modules/jsx-plus.js
@@ -216,6 +216,7 @@ function transformDirectiveList(parsed, code, adapter) {
         // Transform x-for forNode to map function
         const properties = [
           t.objectProperty(params[0], params[0]),
+          t.objectProperty(params[1], params[1]),
           t.objectProperty(t.identifier('_key'), renamedKey),
         ];
         const loopFnBody = t.blockStatement([

--- a/packages/jsx-compiler/src/modules/list.js
+++ b/packages/jsx-compiler/src/modules/list.js
@@ -69,6 +69,7 @@ function transformMapMethod(path, parsed, code, adapter) {
         const forIndex = params[1];
         const properties = [
           t.objectProperty(params[0], params[0]),
+          t.objectProperty(renamedIndex, renamedIndex),
           t.objectProperty(t.identifier('_key'), renamedKey),
         ];
 


### PR DESCRIPTION
编译时小程序中，保留 renamed index 数据导出