### PR TITLE
feat(miniapp): support delete useless components

### DIFF
--- a/packages/rax-miniapp-runtime-webpack-plugin/src/generators/templates/baseTemplate.js
+++ b/packages/rax-miniapp-runtime-webpack-plugin/src/generators/templates/baseTemplate.js
@@ -178,7 +178,9 @@ function createMiniComponents(components, derivedComponents, adapter) {
  * @param {Object} customComponentsConfig - Configured by developer using build script plugin
  */
 function modifyInternalComponents(internalComponents, customComponentsConfig) {
+  const { 'delete': deletedComponents = [] } = customComponentsConfig;
   const result = Object.assign({}, internalComponents);
+  deletedComponents.forEach(deletedComponent => delete result[toCamel(deletedComponent)]);
   Object.keys(customComponentsConfig).forEach(comp => {
     const componentConfig = customComponentsConfig[comp];
     const { add: added = {}, 'delete': deleted = {}} = componentConfig;


### PR DESCRIPTION
- [x] Rax 小程序目前默认会在 template 中配置所有原生小程序内置组件，使得项目初始体积较大。而且由于 Rax 小程序的高度灵活性，工程无法在编译期识别用户使用到的组件，因此在 build.json 的 template 中增加属性 delete 属性，供用户进行进阶式删减组件操作，减小 template 体积，示例如下：

```json
"miniapp": {
  "template": {
    "delete": ["canvas", "progress"]
  }
}
```