### PR TITLE
fix: avoid the update in 'replaceChild'  if both nodes are Comment node

### DIFF
--- a/packages/miniapp-render/CHANGELOG.md
+++ b/packages/miniapp-render/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.8.4] - 2021-09-16
+
+### Changed
+
+- Avoid the update in `replaceChild` if both nodes are Comment node
+
 ## [2.8.3] - 2021-09-09
 
 ### Changed

--- a/packages/miniapp-render/package.json
+++ b/packages/miniapp-render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miniapp-render",
-  "version": "2.8.3",
+  "version": "2.8.4",
   "description": "DOM simulator for MiniApp",
   "files": [
     "dist"

--- a/packages/miniapp-render/src/node/element.js
+++ b/packages/miniapp-render/src/node/element.js
@@ -9,6 +9,7 @@ import cache from '../utils/cache';
 import { toDash, omitFalsyFields, joinClassNames } from '../utils/tool';
 import { simplifyDomTree, traverse } from '../utils/tree';
 import { BUILTIN_COMPONENT_LIST, STATIC_COMPONENTS, PURE_COMPONENTS, CATCH_COMPONENTS, APPEAR_COMPONENT, ANCHOR_COMPONENT } from '../constants';
+import Comment from './comment';
 
 class Element extends Node {
   constructor(options) {
@@ -439,6 +440,10 @@ class Element extends Node {
     node.parentNode = this;
     if (this._isRendered()) {
       node.__rendered = true;
+
+      // avoid the update if both are Comment node
+      if (node instanceof Comment && old instanceof Comment) return old;
+
       // Trigger update
       let payload;
       if (isMiniApp) {


### PR DESCRIPTION
修复：当新老节点都为注释节点时，忽略在 replaceChild 函数中更新；

问题：当使用 Fragment 时，无论内容是否发生变化，都会触发更新

修改前：
![image](https://user-images.githubusercontent.com/3948124/133579034-d557e010-b5a2-4f0d-9c62-32639c78b466.png)
修改后：
![image](https://user-images.githubusercontent.com/3948124/133579107-f1f819fb-612b-4478-822e-3dcb75a69d80.png)
