### PR TITLE
支持if else后面只有一条语句、没有大括号的情况

### DIFF
--- a/packages/jsx-compiler/src/modules/condition.js
+++ b/packages/jsx-compiler/src/modules/condition.js
@@ -44,8 +44,8 @@ function transformRenderFunction(renderPath, adapter) {
         }
 
         if (!alternatePath.isIfStatement() && alternatePath.node) {
-          const alternateBodyPath = alternatePath.get('body');
-          if (alternateBodyPath) {
+          if (alternatePath.isBlockStatement()) {
+            const alternateBodyPath = alternatePath.get('body');
             alternateBodyPath.map((statementPath) => {
               handleAlternate(
                 statementPath.get('expression'),
@@ -322,7 +322,7 @@ function handleConsequent(path, expressionPath, templateMap, renderScope, adapte
         // Remove only if the expression contains JSX
         expressionPath.remove();
       }
-    }
+    } else handleAlternate(expressionPath, templateMap, adapter)
   }
 }
 


### PR DESCRIPTION
原有的条件编译在遇到else后面没有大括号的情况会导致编译出现错误：
![image](https://user-images.githubusercontent.com/31367417/134844134-663c0ddc-88ce-4e73-ade7-01c948a2061e.png)
现在改动jsx-compiler支持了这种情况。