### PR TITLE
Fix: Bind native events on page instance other than page component

### DIFF
--- a/packages/jsx2mp-runtime/CHANGELOG.md
+++ b/packages/jsx2mp-runtime/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.4.25] - 2021-10-21
+
+### Fixed
+
+- Bind native events on page instance other than page component
+
 ## [0.4.24] - 2021-09-26
 
 ### Changed

--- a/packages/jsx2mp-runtime/package.json
+++ b/packages/jsx2mp-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx2mp-runtime",
-  "version": "0.4.24",
+  "version": "0.4.25-0",
   "description": "Runtime for jsx2mp.",
   "miniprogram": ".",
   "files": [

--- a/packages/jsx2mp-runtime/package.json
+++ b/packages/jsx2mp-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx2mp-runtime",
-  "version": "0.4.25-0",
+  "version": "0.4.25",
   "description": "Runtime for jsx2mp.",
   "miniprogram": ".",
   "files": [

--- a/packages/jsx2mp-runtime/src/component.js
+++ b/packages/jsx2mp-runtime/src/component.js
@@ -53,6 +53,7 @@ export default class Component {
     this.hooks = [];
     this._hookID = 0;
     this._keyCache = new Set();
+    this.__nativeEventMap = {};
 
     this._pendingStates = [];
     this._pendingCallbacks = [];
@@ -308,7 +309,7 @@ export default class Component {
       if (isFunction(hook.destory)) hook.destory();
     });
     // Clean up page cycle callbacks
-    this.__proto__.__nativeEventMap = {};
+    this.__nativeEventMap = {};
     this._internal.instance = null;
     this._internal = null;
     this.__mounted = false;

--- a/packages/jsx2mp-runtime/src/nativeEventListener.js
+++ b/packages/jsx2mp-runtime/src/nativeEventListener.js
@@ -4,9 +4,6 @@ import getNativeEventBindTarget from './adapter/getNativeEventBindTarget';
 import { EVENTS_LIST } from './cycles';
 
 export function registerEventsInConfig(Klass, events = []) {
-  if (!Klass.prototype.__nativeEventMap) {
-    Klass.prototype.__nativeEventMap = {};
-  }
   events.forEach(eventName => {
     const shouldReturnConfig = EVENTS_LIST.indexOf(eventName) < 0; // shouldReturnConfig controls the events injected into Page obj or Page.events obj
     const eventBindTarget = getNativeEventBindTarget(Klass, shouldReturnConfig);
@@ -15,8 +12,9 @@ export function registerEventsInConfig(Klass, events = []) {
       // onShareAppMessage need receive callback execute return
       defaultLifeCycleEvent && defaultLifeCycleEvent.apply(this, args); // Execute default lifecycle events like onShow
       let ret;
-      if (Klass.prototype.__nativeEventMap[eventName]) {
-        Klass.prototype.__nativeEventMap[eventName].forEach(callback => ret = callback(...args));
+      const pageInstance = getPageInstance();
+      if (pageInstance.__nativeEventMap[eventName]) {
+        pageInstance.__nativeEventMap[eventName].forEach(callback => ret = callback(...args));
       }
       return ret;
     };
@@ -30,16 +28,16 @@ export function registerNativeEventListeners(component, events) {
 
 export function addNativeEventListener(eventName, callback) {
   const pageInstance = getPageInstance();
-  if (!pageInstance.__proto__.__nativeEventMap[eventName]) {
-    pageInstance.__proto__.__nativeEventMap[eventName] = [];
+  if (!pageInstance.__nativeEventMap[eventName]) {
+    pageInstance.__nativeEventMap[eventName] = [];
   }
-  pageInstance.__proto__.__nativeEventMap[eventName].push(callback);
+  pageInstance.__nativeEventMap[eventName].push(callback);
 }
 
 export function removeNativeEventListener(eventName, callback) {
   const pageInstance = getPageInstance();
-  if (pageInstance.__proto__.__nativeEventMap[eventName]) {
-    pageInstance.__proto__.__nativeEventMap[eventName] = pageInstance.__proto__.__nativeEventMap[eventName].filter(fn => fn !== callback);
+  if (pageInstance.__nativeEventMap[eventName]) {
+    pageInstance.__nativeEventMap[eventName] = pageInstance.__nativeEventMap[eventName].filter(fn => fn !== callback);
   }
 }
 


### PR DESCRIPTION
修改前：`addNativeEventListener` 中注册的事件被绑定在页面组件上，导致同一个页面组件实例出来的不同页面会共享事件。

修改后：`addNativeEventListener` 中注册的事件被绑定在页面实例上，解决共享事件的问题。
