### PR TITLE
fix(miniapp): onCanvasReady can't emit

### DIFF
--- a/packages/miniapp-render/src/builtInComponents/canvas.js
+++ b/packages/miniapp-render/src/builtInComponents/canvas.js
@@ -1,3 +1,6 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { isMiniApp } from 'universal-env';
+
 const canvas = {
   name: 'canvas',
   singleEvents: [{
@@ -25,5 +28,12 @@ const canvas = {
     eventName: 'error'
   }]
 };
+
+if (isMiniApp) {
+  canvas.singleEvents = canvas.singleEvents.concat([{
+    name: 'onCanvasReady',
+    eventName: 'ready'
+  }]);
+}
 
 export default canvas;

--- a/packages/rax-miniapp-runtime-webpack-plugin/src/platforms/ali.js
+++ b/packages/rax-miniapp-runtime-webpack-plugin/src/platforms/ali.js
@@ -626,6 +626,7 @@ const Canvas = {
     'disable-scroll': 'false',
   },
   events: {
+    Ready: '',
     ...touchEvents,
   },
   basicEvents: {


### PR DESCRIPTION
- [x] 支持阿里小程序 canvas 组件的 ready 事件（需开启 appx 2.0）