### PR TITLE
fix(jsx2mp): can't find correct app_css usingComponents path

### DIFF
--- a/packages/jsx2mp-loader/CHANGELOG.md
+++ b/packages/jsx2mp-loader/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.4.32] - 2021-11-03
+
+### Fixed
+
+- Can't find app_css custom component when the file and app_css are in the same directory
+
 ## [0.4.31] - 2021-11-01
 
 ### Changed

--- a/packages/jsx2mp-loader/package.json
+++ b/packages/jsx2mp-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx2mp-loader",
-  "version": "0.4.31",
+  "version": "0.4.32",
   "description": "",
   "files": [
     "src"

--- a/packages/jsx2mp-loader/src/component-loader.js
+++ b/packages/jsx2mp-loader/src/component-loader.js
@@ -95,7 +95,7 @@ module.exports = async function componentLoader(content) {
   // Only works when developing miniapp plugin, to declare the use of __app_css component
   if (injectAppCssComponent) {
     const appCssComponentPath = resolve(outputPath, '__app_css', 'index');
-    const relativeAppCssComponentPath = relative(distFileDir, appCssComponentPath);
+    const relativeAppCssComponentPath = addRelativePathPrefix(relative(distFileDir, appCssComponentPath));
     config.usingComponents = {
       '__app_css': relativeAppCssComponentPath,
       ...config.usingComponents

--- a/packages/jsx2mp-loader/src/page-loader.js
+++ b/packages/jsx2mp-loader/src/page-loader.js
@@ -101,7 +101,7 @@ module.exports = async function pageLoader(content) {
   // Only works when developing miniapp plugin, to declare the use of __app_css component
   if (injectAppCssComponent) {
     const appCssComponentPath = resolve(outputPath, '__app_css', 'index');
-    const relativeAppCssComponentPath = relative(pageDistDir, appCssComponentPath);
+    const relativeAppCssComponentPath = addRelativePathPrefix(relative(pageDistDir, appCssComponentPath));
     config.usingComponents = {
       '__app_css': relativeAppCssComponentPath,
       ...config.usingComponents


### PR DESCRIPTION
- [x] fix: 当页面或组件与 app_css 同级时，不加 ./ 前缀将导致小程序 IDE 无法在 usingComponents 中获取 app_css 自定义组件