### PR TITLE
fix:just replace 'rem' in css value of specific pattern, to prevent break css name or css key

### DIFF
--- a/packages/jsx2mp-loader/src/styleProcessor.js
+++ b/packages/jsx2mp-loader/src/styleProcessor.js
@@ -36,7 +36,9 @@ async function compileCSS(cssType, content, filename) {
   return processedContent;
 }
 
-function convertCSSUnit(raw, originExt = 'rem', targetExt = 'rpx') {
+function convertCSSUnit(raw, originExt = '', targetExt = '') {
+  if (!(originExt && targetExt)) return raw;
+
   const regexp = new RegExp(originExt, 'g');
   return raw.replace(regexp, targetExt); // Maybe could use postcss plugin instead.
 }
@@ -56,7 +58,9 @@ async function processCSS(cssFiles, sourcePath) {
       const relativePath = relative(sourcePath, cssFile.filename);
       assets[relativePath + '.js'] = createCSSModule(cssFile.content);
     } else if (cssFile.type === 'cssFile') {
-      style += convertCSSUnit(cssFile.content);
+      // just replace 'rem' in css value of specific pattern, to prevent break css name or css key
+      // pattern eg. ": 1rem;", ": .5rem;", ":1rem ;", ":1rem \n"
+      style += convertCSSUnit(cssFile.content, '(:\s*(?:\d|\.)+)rem(\s*(?:;|\n))', '$1rpx$2');
     }
   }
   return { style, assets };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8348072/147845607-d0a6c8f2-5145-4394-879f-1fa71df93b6c.png)

问题：现在的rem 替换为 rpx 采用的直接字符串替换；这样会误伤 css 类名中的 rem，如上图。

修复：只替换 css 属性值内的 rem，且特征符合 css 单位的有效语法。

注： converCSSUnit 的参数如果走默认值，其他使用该函数的地方也会有此问题（虽然搜索整个仓库只有一处调用），所以去掉了默认值，加了检查。 调用处明确传参进来。