### PR TITLE
fix(jsx2mp-loader): component of pure js support shaking by filename postfix

### DIFF
--- a/packages/jsx2mp-loader/CHANGELOG.md
+++ b/packages/jsx2mp-loader/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.4.35] - 2022-02-10
+
+### Fixed
+
+- component of pure js support shaking by filename postfix
+
 ## [0.4.34] - 2022-01-06
 
 ### Fixed

--- a/packages/jsx2mp-loader/package.json
+++ b/packages/jsx2mp-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx2mp-loader",
-  "version": "0.4.34",
+  "version": "0.4.35",
   "description": "",
   "files": [
     "src"

--- a/packages/jsx2mp-loader/src/script-loader.js
+++ b/packages/jsx2mp-loader/src/script-loader.js
@@ -72,7 +72,7 @@ module.exports = function scriptLoader(content) {
     outputContent = { code: rawContent };
     outputOption = {
       outputPath: {
-        code: removeExt(distSourcePath) + '.js'
+        code: removeExt(distSourcePath, platform.type) + '.js'
       },
       mode,
       externalPlugins: [


### PR DESCRIPTION
纯api类型的组件模块通过文件后缀名（index.ali.js | index.wechat.js | ... ）做分端构建时，虽然他端文件剔除了，但是文件名称和被引用路径不一致，会导致运行出错（如：产物模块 util/index.ali.js 与被引用 import Util from '../apis/util/index'）。故纯API模块分端构建后的产物文件名改为index.js来修复这个问题。