### PR TITLE
fix: convertCSSUnit rem 2 rpx

### DIFF
--- a/packages/jsx2mp-loader/CHANGELOG.md
+++ b/packages/jsx2mp-loader/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.4.36] - 2022-02-22
+
+### Fixed
+
+- just replace 'rem' in css value of specific pattern, to prevent break css name or css key
+
 ## [0.4.35] - 2022-02-10
 
 ### Fixed

--- a/packages/jsx2mp-loader/package.json
+++ b/packages/jsx2mp-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx2mp-loader",
-  "version": "0.4.35",
+  "version": "0.4.36",
   "description": "",
   "files": [
     "src"

--- a/packages/jsx2mp-loader/src/styleProcessor.js
+++ b/packages/jsx2mp-loader/src/styleProcessor.js
@@ -60,7 +60,7 @@ async function processCSS(cssFiles, sourcePath) {
     } else if (cssFile.type === 'cssFile') {
       // just replace 'rem' in css value of specific pattern, to prevent break css name or css key
       // pattern eg. ": 1rem;", ": .5rem;", ":1rem ;", ":1rem \n"
-      style += convertCSSUnit(cssFile.content, '(:\s*(?:\d|\.)+)rem(\s*(?:;|\n))', '$1rpx$2');
+      style += convertCSSUnit(cssFile.content, '(:\\s*[.0-9]+)rem(\\s*(?:;|\\n))', '$1rpx$2');
     }
   }
   return { style, assets };


### PR DESCRIPTION
修复之前的写法存在两个问题：
1. \s* 的写法有问题，实际匹配的是多个 's'，未达到匹配多个空白符的目的；
2. 基于第一个问题，会出现 new RegExp('.+rem', 'g')，匹配特长的字符串时，会因为回溯过多导致卡死；（千郎那个问题正是在含有较长base64时触发的）