### PR TITLE
fix: RegExp of function removeExt

### DIFF
--- a/packages/jsx2mp-loader/CHANGELOG.md
+++ b/packages/jsx2mp-loader/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.4.36] - 2022-03-08
+
+### Fixed
+
+- Fix RegExp of function removeExt. Just replace file that like 'index.ali.js', excludes 'ali.js', that's bug in v0.4.35.
+
 ## [0.4.35] - 2022-02-10
 
 ### Fixed

--- a/packages/jsx2mp-loader/package.json
+++ b/packages/jsx2mp-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx2mp-loader",
-  "version": "0.4.35",
+  "version": "0.4.36",
   "description": "",
   "files": [
     "src"

--- a/packages/jsx2mp-loader/src/utils/pathHelper.js
+++ b/packages/jsx2mp-loader/src/utils/pathHelper.js
@@ -2,7 +2,7 @@ const { extname, sep, join } = require('path');
 
 function removeExt(path, platform) {
   const ext = extname(path);
-  const extReg = new RegExp(`${platform ? `(.${platform})?` : ''}${ext}$`.replace(/\\./g, '\\.'));
+  const extReg = new RegExp(`${platform ? `(.${platform})?` : ''}${ext}$`.replace(/\./g, '\\.'));
   return path.replace(extReg, '');
 }
 


### PR DESCRIPTION
修复 removeExt 的正则错误，之前的写法在开启纯 api 文件的分端构建后（[pr#278](https://github.com/raxjs/miniapp/pull/278)），会误伤 dir/ali.js, dir/wechat.js 这种格式的文件，导致其构建产物变为 dir.js。

之前的正则表达式字面量写法的 /\\\\./ 有问题，’.‘ 的转义最终没有生效。简单测试如图：
![image](https://user-images.githubusercontent.com/8348072/157204183-e51c22b2-e199-4d68-9874-5e4494e2e8a7.png)

故修复让其只对 dir/xx.ali.js, dir/xx.wechat.js 这样的文件名生效 分端构建。

----

目前通过 env 判断来动态 require 对应端文件是常见的纯 api 文件实现 “分端构建” 的方式，而这种方式下对文件的命名，开发者的习惯都是以 ali.js wechat.js 来命名的。如下图：
![image](https://user-images.githubusercontent.com/8348072/157204746-55ec04d2-191a-435a-95d3-df208898dc81.png)
