### PR TITLE
fix: needCopyList[i].to error in setEntry()

### DIFF
--- a/packages/miniapp-compile-config/src/setEntry.js
+++ b/packages/miniapp-compile-config/src/setEntry.js
@@ -46,7 +46,7 @@ function setEntry(config, routes, options) {
   nativeRoutes.forEach(({ source }) => {
     needCopyList.push({
       from: dirname(join('src', source)),
-      to: dirname(join('src', source)),
+      to: dirname(source),
     });
   });
   configEntry(config, normalRoutes, options);


### PR DESCRIPTION
如沟通。编译时方案下，“引用原生小程序页面”功能，将原生页面放在 `pages/` 目录下时，拷贝后的路径有误，被放到 `build/miniapp/src/pages/` 下了，正确应该是 `build/miniapp/pages/` 下。 这里修复一下这个 `to`  的路径。