### PR TITLE
fix:css file test

### DIFF
--- a/packages/rax-miniapp-runtime-webpack-plugin/src/utils/processAssets.js
+++ b/packages/rax-miniapp-runtime-webpack-plugin/src/utils/processAssets.js
@@ -43,7 +43,7 @@ if (typeof getApp === 'function') {
         content,
         footerContent
       ));
-    } else if (/\.css/.test(fileName)) {
+    } else if (/\.css$/.test(fileName)) {
       const content = compilation.assets[fileName].source();
       // Delete original asset
       delete compilation.assets[fileName];


### PR DESCRIPTION
避免开启sourcemap 之后的。xxx.css.map 文件被处理导致格式异常报错