### PR TITLE
fix(bytedance): componentTag don't sopport the name start with '_'

### DIFF
--- a/packages/jsx-compiler/src/adapter.js
+++ b/packages/jsx-compiler/src/adapter.js
@@ -112,6 +112,8 @@ const parserAdapters = {
     // Handle rax-slider and rax-swiper
     insertSwiperSlot: true,
     needRegisterProps: true,
+    // ComponentTag don't sopport that start with '_'.
+    compTagHeadNoUnderline: true
   },
   componentCommonProps
 };

--- a/packages/jsx-compiler/src/modules/components.js
+++ b/packages/jsx-compiler/src/modules/components.js
@@ -31,8 +31,14 @@ function transformIdentifierComponentName(path, alias, dynamicValue, parsed, opt
     renderFunctionPath,
     componentDependentProps,
   } = parsed;
+
   // Miniapp template tag name does not support special characters.
-  const aliasName = alias.name.replace(/@|\//g, '_');
+  let aliasName = alias.name.replace(/@|\//g, '_');
+  // ByteDance MicroApp's componentTag don't sopport the name start with '_'. 
+  if (aliasName.indexOf('_') === 0 && options.adapter.compTagHeadNoUnderline) {
+    aliasName = aliasName.replace('_', '');
+  }
+  
   const componentTag = alias.default ? aliasName : `${aliasName}-${alias.local.toLowerCase()}`;
   replaceComponentTagName(path, t.jsxIdentifier(componentTag));
   node.isCustomEl = alias.isCustomEl;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8348072/188323418-62ddaed3-c977-4d18-8388-bac93f73959d.png)
如图，字节小程序IDE 上遇到以下划线开头的自定义组件命名，不识别（语法不高亮），渲染异常。

命名去掉开头下划线后，渲染正常，如下图：
![image](https://user-images.githubusercontent.com/8348072/188323548-64a4210f-08f1-4b2d-8f49-c65976c3bbc3.png)

故在字节小程序上的自定义组件命名开头是 ’@' 时，做特殊处理，来规避此问题。
Npm分组都是 '@xxx/' 开头的格式，转为 ‘xxx_' 格式，不会出现碰撞。