### PR TITLE
feat(index): Add bytedance support

### DIFF
--- a/packages/jsx-compiler/src/adapter.js
+++ b/packages/jsx-compiler/src/adapter.js
@@ -103,6 +103,18 @@ const parserAdapters = {
       ...componentCommonProps.bytedance,
       className: '__rax-text'
     },
+    icon: {
+      ...componentCommonProps.bytedance,
+      className: ''
+    },
+    image: {
+      ...componentCommonProps.bytedance,
+      className: ''
+    },
+    'scroll-view': {
+      ...componentCommonProps.bytedance,
+      className: ''
+    },
     styleKeyword: true,
     slotScope: false,
     // Need transform onClick -> bindonclick

--- a/packages/jsx-compiler/src/getCompiledComponents.js
+++ b/packages/jsx-compiler/src/getCompiledComponents.js
@@ -12,7 +12,10 @@ module.exports = function(platform) {
     case 'bytedance':
       return {
         'rax-view': 'view',
-        'rax-text': 'text'
+        'rax-text': 'text',
+        'rax-image': 'image',
+        'rax-icon': 'icon',
+        'rax-scrollview': 'scroll-view'
       };
   }
 };


### PR DESCRIPTION
Solve the problem that the bytedance microapp can't pass through the className property by replace the native miniapp component tag in the compiler.